### PR TITLE
Fix bash syntax error

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -18,7 +18,7 @@ check_env() {
             -o -z "$AWS_SECRET_ACCESS_KEY" \
             -o -z "$S3_BUCKET" \
             -o -z "$S3_PREFIX" \
-            -o -z "$TEST_JAR_PATH"]; then
+            -o -z "$TEST_JAR_PATH" ]; then
         echo "Missing required env. See check in ${BIN_DIR}/test.sh."
         env
         exit 1


### PR DESCRIPTION
In Jenkins logs:

```
bin/test.sh: line 13: [: missing `]'
```