### PR TITLE
[SPARK-339] Add support for Kerberos args to Go CLI module

### DIFF
--- a/cli/dcos-spark/main.go
+++ b/cli/dcos-spark/main.go
@@ -38,7 +38,7 @@ type SparkCommand struct {
 }
 
 func (cmd *SparkCommand) runSubmit(c *kingpin.ParseContext) error {
-	jsonPayload, err := submitJson(cmd.submitArgs, cmd.submitDockerImage, cmd.submitEnv)
+	jsonPayload, err := buildSubmitJson(cmd.submitArgs, cmd.submitDockerImage, cmd.submitEnv)
 	if err != nil {
 		return err
 	}

--- a/cli/dcos-spark/main.go
+++ b/cli/dcos-spark/main.go
@@ -5,27 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mesosphere/dcos-commons/cli"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
 	"log"
 	"strings"
 )
 
 func main() {
-	app, err := cli.NewApp("0.1.0", "Mesosphere", "CLI for launching/accessing Spark jobs")
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	cli.HandleCommonFlags(app, "spark", "Spark DC/OS CLI Module")
+	app := cli.New()
 	handleCommands(app)
-
 	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }
 
 type SparkCommand struct {
-	submissionId string
-
+	submissionId      string
 	submitArgs        string
 	submitDockerImage string
 	submitEnv         map[string]string
@@ -37,15 +31,17 @@ type SparkCommand struct {
 	logFile   string
 }
 
-func (cmd *SparkCommand) runSubmit(c *kingpin.ParseContext) error {
+func (cmd *SparkCommand) runSubmit(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
 	jsonPayload, err := buildSubmitJson(cmd.submitArgs, cmd.submitDockerImage, cmd.submitEnv)
 	if err != nil {
 		return err
 	}
-	httpResponse := cli.HTTPPostJSON(
+	responseBytes, err := client.HTTPServicePostJSON(
 		fmt.Sprintf("/v1/submissions/create/%s", cmd.submissionId), jsonPayload)
+	if err != nil {
+		return err
+	}
 
-	responseBytes := cli.GetResponseBytes(httpResponse)
 	responseJson := make(map[string]interface{})
 	err = json.Unmarshal(responseBytes, &responseJson)
 	if err != nil {
@@ -55,7 +51,7 @@ func (cmd *SparkCommand) runSubmit(c *kingpin.ParseContext) error {
 	err = checkSparkJSONResponse(responseJson)
 	if err != nil {
 		// Failure! Print the raw message:
-		cli.PrintJSONBytes(responseBytes, httpResponse.Request)
+		client.PrintJSONBytes(responseBytes)
 		return err
 	}
 
@@ -75,12 +71,16 @@ func (cmd *SparkCommand) runSubmit(c *kingpin.ParseContext) error {
 	return nil
 }
 
-func (cmd *SparkCommand) runStatus(c *kingpin.ParseContext) error {
-	httpResponse := cli.HTTPGet(fmt.Sprintf("/v1/submissions/status/%s", cmd.submissionId))
-	responseBytes := cli.GetResponseBytes(httpResponse)
-	cli.PrintJSONBytes(responseBytes, httpResponse.Request)
+func (cmd *SparkCommand) runStatus(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
+	responseBytes, err := client.HTTPServiceGet(fmt.Sprintf("/v1/submissions/status/%s", cmd.submissionId))
+	if err != nil {
+		client.PrintJSONBytes(responseBytes)
+		return err
+	}
+
+	client.PrintJSONBytes(responseBytes)
 	responseJson := make(map[string]interface{})
-	err := json.Unmarshal(responseBytes, &responseJson)
+	err = json.Unmarshal(responseBytes, &responseJson)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (cmd *SparkCommand) runStatus(c *kingpin.ParseContext) error {
 	return checkSparkJSONResponse(responseJson)
 }
 
-func (cmd *SparkCommand) runLog(c *kingpin.ParseContext) error {
+func (cmd *SparkCommand) runLog(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
 	args := []string{"task", "log", "--completed"}
 	if cmd.logFollow {
 		args = append(args, "--follow")
@@ -114,47 +114,57 @@ func (cmd *SparkCommand) runLog(c *kingpin.ParseContext) error {
 	if len(cmd.logFile) != 0 {
 		args = append(args, cmd.logFile)
 	}
-	result, err := cli.RunCLICommand(args...)
+	result, err := client.RunCLICommand(args...)
 	// Always print output from CLI, which may contain user-facing errors (like 'log file not found'):
 	fmt.Printf("%s\n", strings.TrimRight(result, "\n"))
 	return err
 }
 
-func (cmd *SparkCommand) runKill(c *kingpin.ParseContext) error {
-	httpResponse := cli.HTTPPost(fmt.Sprintf("/v1/submissions/kill/%s", cmd.submissionId))
-	responseBytes := cli.GetResponseBytes(httpResponse)
-	cli.PrintJSONBytes(responseBytes, httpResponse.Request)
+func (cmd *SparkCommand) runKill(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
+	responseBytes, err := client.HTTPServicePost(fmt.Sprintf("/v1/submissions/kill/%s", cmd.submissionId))
+	if err != nil {
+		client.PrintJSONBytes(responseBytes)
+		return err
+	}
+	client.PrintJSONBytes(responseBytes)
 	responseJson := make(map[string]interface{})
-	err := json.Unmarshal(responseBytes, &responseJson)
+	err = json.Unmarshal(responseBytes, &responseJson)
 	if err != nil {
 		return err
 	}
 	return checkSparkJSONResponse(responseJson)
 }
 
-func (cmd *SparkCommand) runWebui(c *kingpin.ParseContext) error {
+func (cmd *SparkCommand) runWebui(a *kingpin.Application, e *kingpin.ParseElement, c *kingpin.ParseContext) error {
 	// Hackish: Create the request we WOULD make, and print the resulting URL:
-	fmt.Printf("%s\n", cli.CreateHTTPRequest("GET", "/ui").URL.String())
+	fmt.Printf("%s\n", client.CreateServiceHTTPRequest("GET", "/ui").URL.String())
 	return nil
 }
 
 func handleCommands(app *kingpin.Application) {
 	cmd := &SparkCommand{submitEnv: make(map[string]string)}
+	run := app.Command("run", "Submit a job to the Spark Mesos Dispatcher").Action(cmd.runSubmit)
 
-	run := app.Command("run", "Submits a new Spark job ala 'spark-submit'").Action(cmd.runSubmit)
-
-	run.Flag("submit-args", fmt.Sprintf("Arguments matching what would be sent to 'spark-submit': %s", sparkSubmitHelp())).Required().PlaceHolder("ARGS").StringVar(&cmd.submitArgs)
+	run.Flag("submit-args", fmt.Sprintf("Arguments matching what would be sent to 'spark-submit': %s",
+		sparkSubmitHelp())).Required().PlaceHolder("ARGS").StringVar(&cmd.submitArgs)
 	run.Flag("docker-image", "Docker image to run the job within").StringVar(&cmd.submitDockerImage)
-	run.Flag("env", "Environment variable(s) to pass into the Spark job.").Short('E').PlaceHolder("ENVKEY=ENVVAL").StringMapVar(&cmd.submitEnv)
+	run.Flag("env", "Environment variable(s) to pass into the Spark job.").
+		Short('E').
+		PlaceHolder("ENVKEY=ENVVAL").
+		StringMapVar(&cmd.submitEnv)
 
-	status := app.Command("status", "Retrieves the status of a submitted Spark job").Action(cmd.runStatus)
-	status.Flag("skip-message", "Omit the additional printout of the 'message' field").BoolVar(&cmd.statusSkipMessage)
+	status := app.Command("status", "Retrieves the status of a submitted Spark job").
+		Action(cmd.runStatus)
+	status.Flag("skip-message", "Omit the additional printout of the 'message' field").
+		BoolVar(&cmd.statusSkipMessage)
 	status.Arg("submission-id", "The ID of the Spark job").Required().StringVar(&cmd.submissionId)
 
 	log := app.Command("log", "Retrieves a log file from a submitted Spark job").Action(cmd.runLog)
 	log.Flag("follow", "Dynamically update the log").BoolVar(&cmd.logFollow)
-	log.Flag("lines_count", "Print the last N lines.").Default("10").UintVar(&cmd.logLines) //TODO "lines"?
-	log.Flag("file", "Specify the sandbox file to print.").Default("stdout").StringVar(&cmd.logFile)
+	log.Flag("lines_count", "Print the last N lines.").
+		Default("10").UintVar(&cmd.logLines) //TODO "lines"?
+	log.Flag("file", "Specify the sandbox file to print.").
+		Default("stdout").StringVar(&cmd.logFile)
 	log.Arg("submission-id", "The ID of the Spark job").Required().StringVar(&cmd.submissionId)
 
 	kill := app.Command("kill", "Aborts a submitted Spark job").Action(cmd.runKill)
@@ -171,7 +181,8 @@ func checkSparkJSONResponse(responseJson map[string]interface{}) error {
 	}
 	successBool, ok := successObj.(bool)
 	if !ok {
-		return errors.New(fmt.Sprintf("Unable to convert 'success' field in response JSON to boolean: %s", successObj))
+		return errors.
+			New(fmt.Sprintf("Unable to convert 'success' field in response JSON to boolean: %s", successObj))
 	}
 	if !successBool {
 		return errors.New("Spark returned success=false")


### PR DESCRIPTION
Tested by launching a job with phony Kerberos args against the Python CLI and then the Go CLI with the same args, then checking the resulting launched job args for differences. From that testing, assuming Python submit works, Go submit should work too..
