### PR TITLE
Show spark log even after the task has completed

### DIFF
--- a/cli/dcos_spark/cli.py
+++ b/cli/dcos_spark/cli.py
@@ -64,7 +64,7 @@ def kill_job(args):
 
 def log_job(args):
     dcos_client = mesos.DCOSClient()
-    task = mesos.get_master(dcos_client).task(args['<submissionId>'])
+    task = mesos.get_master(dcos_client).task(args['<submissionId>'], True)
     log_file = args.get('--file', "stdout")
     if log_file is None:
         log_file = "stdout"


### PR DESCRIPTION
If you try to run dcos spark log after the task has finished it would error out since it cannot find the task. The error would look something like :

```
Traceback (most recent call last):
  File "/Users/harpreet/.dcos/subcommands/spark/env/bin/dcos-spark", line 11, in <module>
    sys.exit(main())
  File "/Users/harpreet/.dcos/subcommands/spark/env/lib/python2.7/site-packages/dcos_spark/cli.py", line 110, in main
    return log_job(args)
  File "/Users/harpreet/.dcos/subcommands/spark/env/lib/python2.7/site-packages/dcos_spark/cli.py", line 67, in log_job
    task = mesos.get_master(dcos_client).task(args['<submissionId>'])
  File "/Users/harpreet/.dcos/subcommands/spark/env/lib/python2.7/site-packages/dcos/mesos.py", line 380, in task
    'Cannot find a task with ID containing "{}"'.format(fltr))
dcos.errors.DCOSException: Cannot find a task with ID containing "driver-20161012174828-0001
```
