### PR TITLE
Make sure LIBPROCESS_IP is defined before setting SPARK_LOCAL_IP to it.

### DIFF
--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -14,7 +14,9 @@ mkdir -p "${HADOOP_CONF_DIR}"
 MESOS_NATIVE_JAVA_LIBRARY=/usr/local/lib/libmesos.so
 
 # Support environments without DNS
-SPARK_LOCAL_IP=${LIBPROCESS_IP}
+if [ -n "$LIBPROCESS_IP" ]; then
+  SPARK_LOCAL_IP=${LIBPROCESS_IP}
+fi
 
 # Options read when launching programs locally with
 # ./bin/run-example or ./bin/spark-submit


### PR DESCRIPTION
@mgummelt This fixes the problem where SPARK_LOCAL_IP is not set properly because it gets overwritten by an empty LIBPROCESS_IP.