### PR TITLE
DCOS HDFS uses /v1/connection 

### DIFF
--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -155,7 +155,7 @@ where `http://mydomain.com/hdfs-config/hdfs-site.xml` and
 URLs.[Learn more][8].
 
 For DC/OS HDFS, these configuration files are served at
-`http://<hdfs.framework-name>.marathon.mesos:<port>/v1/connect`, where
+`http://<hdfs.framework-name>.marathon.mesos:<port>/v1/connection`, where
 `<hdfs.framework-name>` is a configuration variable set in the HDFS
 package, and `<port>` is the port of its marathon app.
 


### PR DESCRIPTION
Versions:
DCOS: 1.7
Spark: 1.0.4-2.0.1
HDFS: 0.9.1-2.6.0

When trying to get the history server working with DCOS's version of HDFS and SPARK, it did configure itself to the DCOS HDFS by default. This is purely a documentation fix to show that the HDFS actually serves the configuration xmls from `/v1/connection`, not `v1/connect`  Using this value in the `hdfs.config-url` made the history server work as expected.