### PR TITLE
Added limitations to docs: app development and Spark shell

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,7 +14,8 @@ does not support R.
 Spark job on a node, it might take longer than you expect because of
 the `docker pull`.
 
-*   DC/OS Spark only supports running the Spark Shell from within the
-DC/OS cluster. For interactive analytics, we
+*   DC/OS Spark only supports running the Spark shell from within a
+DC/OS cluster. See [the Spark Shell section](spark-shell.md) for more information. 
+For interactive analytics, we
 recommend Zeppelin, which supports visualizations and dynamic
 dependency management.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,10 +8,13 @@ enterprise: 'yes'
 *   DC/OS Spark only supports submitting jars and Python scripts. It
 does not support R.
 
+*   Mesosphere does not provide support for Spark app development.
+
 *   Spark jobs run in Docker containers. The first time you run a
 Spark job on a node, it might take longer than you expect because of
 the `docker pull`.
 
-*   For interactive analytics, we
+*   DC/OS Spark only supports running the Spark Shell from within the
+DC/OS cluster. For interactive analytics, we
 recommend Zeppelin, which supports visualizations and dynamic
 dependency management.


### PR DESCRIPTION
Added documentation about not supporting Spark app development and Spark shell needing to run inside cluster.