### PR TITLE
Multiple hadoop profiles

### DIFF
--- a/bin/dist.sh
+++ b/bin/dist.sh
@@ -1,29 +1,7 @@
 #!/bin/bash
-#
-# 1. Builds a spark distribution
-# 2. Uploads it to S3
-# 3. Creates a properties file spark_dist_uri.properties containing the URL of the distribution.
+# Builds a spark distribution
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SPARK_DIR="${DIR}/../../spark"
 
-check_env() {
-    # Check env early, before starting the cluster:
-    if [ -z "$S3_BUCKET" -o -z "${S3_PREFIX+x}" ]; then
-        echo "Missing required env. See check in ${BIN_DIR}/dist.sh."
-        env
-        exit 1
-    fi
-}
-
-function write_properties() {
-    SPARK_FILENAME=$(basename $(ls ${SPARK_DIR}/spark*.tgz))
-    SPARK_DIST_URI="http://${S3_BUCKET}.s3.amazonaws.com/${S3_PREFIX}/spark/${GIT_COMMIT}/${SPARK_FILENAME}"
-    echo "SPARK_DIST_URI=${SPARK_DIST_URI}" > spark_dist_uri.properties
-}
-
-check_env
 source "${DIR}/jenkins.sh"
 make_distribution
-upload_to_s3
-write_properties

--- a/bin/jenkins-dist-publish.sh
+++ b/bin/jenkins-dist-publish.sh
@@ -5,44 +5,42 @@
 
 set -e -x -o pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SPARK_DIR="${DIR}/../../spark"
-SPARK_BUILD_DIR=${DIR}/..
 
-function run_tests() {
-    # test
-    source bin/jenkins.sh
-    install_cli
-    docker_login
-    make dist && export $(cat spark_dist_uri.properties)
-    make universe && export $(cat "${WORKSPACE}/stub-universe.properties")
-    make test
-
-}
-
-function publish() {
-    HADOOP_VERSIONS=( "2.4" "2.6" "2.7" )
+function publish_dists() {
+    set_hadoop_versions
     for HADOOP_VERSION in "${HADOOP_VERSIONS[@]}"
     do
-        pushd "${SPARK_DIR}"
-        ./build/mvn help:all-profiles | grep "hadoop-${HADOOP_VERSION}"
-        PROFILE_EXISTS=$?
-        popd
-
-        if [ ${PROFILE_EXISTS} -eq 0 ]; then
-            HADOOP_VERSION=${HADOOP_VERSION} make dist
-            rename_dist
-            AWS_ACCESS_KEY_ID=${PROD_AWS_ACCESS_KEY_ID} \
-                             AWS_SECRET_ACCESS_KEY=${PROD_AWS_SECRET_ACCESS_KEY} \
-                             S3_BUCKET=${PROD_S3_BUCKET} \
-                             S3_PREFIX=${PROD_S3_PREFIX} \
-                             upload_to_s3
+        if does_hadoop_profile_exist "${HADOOP_VERSION}"; then
+            publish_dist "${HADOOP_VERSION}"
+            # publish_docker "${HADOOP_VERSION}"
         fi
-        popd
     done
 }
 
+# $1: hadoop version (e.g. "2.6")
+function does_hadoop_profile_exist() {
+    (cd "${SPARK_DIR}" && ./build/mvn help:all-profiles | grep "hadoop-$1")
+}
+
+# $1: hadoop version (e.g. "2.6")
+function publish_dist() {
+    HADOOP_VERSION=$1 make dist
+    rename_dist
+    AWS_ACCESS_KEY_ID=${PROD_AWS_ACCESS_KEY_ID} \
+                     AWS_SECRET_ACCESS_KEY=${PROD_AWS_SECRET_ACCESS_KEY} \
+                     S3_URL="s3://${PROD_S3_BUCKET}/${PROD_S3_PREFIX}/" \
+                     upload_to_s3
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SPARK_DIR="${DIR}/../../spark"
+SPARK_BUILD_DIR="${DIR}/../../spark-build"
+SPARK_VERSION=${GIT_BRANCH#origin/tags/custom-} # e.g. "2.0.2"
+source "${DIR}/jenkins.sh"
+
 pushd "${SPARK_BUILD_DIR}"
-run_tests
-publish
+install_cli
+docker_login
+# build_and_test
+publish_dists
 popd

--- a/bin/jenkins-dist-test.sh
+++ b/bin/jenkins-dist-test.sh
@@ -3,15 +3,14 @@
 set -e -x -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SPARK_BUILD_DIR=${DIR}/..
+SPARK_BUILD_DIR="${DIR}/.."
+SPARK_DIR="${DIR}/../../spark"
 
 function run() {
     source bin/jenkins.sh
     install_cli
     docker_login
-    make dist && export $(cat spark_dist_uri.properties)
-    make universe && export $(cat "${WORKSPACE}/stub-universe.properties")
-    make test
+    build_and_test
 }
 
 pushd "${SPARK_BUILD_DIR}"

--- a/bin/jenkins-package-publish.sh
+++ b/bin/jenkins-package-publish.sh
@@ -2,17 +2,40 @@
 
 set -e -x -o pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SPARK_BUILD_DIR=${DIR}/..
+function publish_docker_images() {
+    local NUM_SPARK_DIST=$(jq ".spark_dist | length" manifest.json)
+    local NUM_SPARK_DIST=$(expr ${NUM_SPARK_DIST} - 1)
+    for i in $(seq 0 ${NUM_SPARK_DIST});
+    do
+        local HADOOP_VERSION=$(jq -r ".spark_dist[${i}].hadoop_version" manifest.json)
+        SPARK_DIST_URI=$(jq -r ".spark_dist[${i}].uri" manifest.json) \
+                      DOCKER_IMAGE="${DOCKER_IMAGE}:$(docker_version ${HADOOP_VERSION})" make docker
+    done
+}
 
-source spark-build/bin/jenkins.sh
+function make_universe() {
+    DOCKER_VERSION=$(docker_version $(default_hadoop_version))
+    DOCKER_BUILD=false \
+                DOCKER_IMAGE=${DOCKER_IMAGE}:${DOCKER_VERSION} \
+                SPARK_DIST_URI=$(default_spark_dist) \
+                make universe
+}
+
+function write_properties() {
+    cp ../stub-universe.properties ../build.properties
+    echo "RELEASE_VERSION=${SPARK_BUILD_VERSION}" >> ../build.properties
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SPARK_BUILD_DIR=${DIR}/../../spark-build
+SPARK_BUILD_VERSION=${GIT_BRANCH#origin/tags/}
+source "${DIR}/jenkins.sh"
 
 pushd "${SPARK_BUILD_DIR}"
+SPARK_VERSION=$(jq -r ".spark_version" manifest.json)
 install_cli
 docker_login
-make universe
-cp ../stub-universe.properties ../build.properties
-VERSION=${GIT_BRANCH#origin/tags/}
-echo "RELEASE_VERSION=${VERSION}" >> ../build.properties
-echo "RELEASE_DOCKER_IMAGE=mesosphere/spark:${VERSION}" >> ../build.properties
+publish_docker_images
+make_universe
+write_properties
 popd

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,6 +50,23 @@ Run the following command to see all configuration options:
 
     $ dcos package describe spark --config
 
+## Customize Spark Distribution
+
+DC/OS Spark does not support arbitrary Spark distributions, but
+Mesosphere does provide multiple pre-built distributions, primarily
+used to select Hadoop versions.  To use one of these distributions,
+first select your desired Spark distribution from here: "<link>", then
+select the corresponding docker image from here:
+https://hub.docker.com/r/mesosphere/spark/tags/, then use those values
+to set the following configuration variables:
+
+    {
+      "service": {
+        "spark-dist-uri": "<spark-dist-uri>"
+        "docker-image": "<docker-image>"
+      }
+    }
+
 # Minimal Installation
 
 For development purposes, you may wish to install Spark on a local

--- a/docs/spark-versions.md
+++ b/docs/spark-versions.md
@@ -1,0 +1,15 @@
+---
+post_title: Spark Distributions
+feature_maturity: stable
+enterprise: 'no'
+---
+
+https://downloads.mesosphere.com/spark/assets/spark-1.6.0.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.1.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.1-1.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.1-2.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.2.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.3-bin-2.4.tgz
+https://downloads.mesosphere.com/spark/assets/spark-1.6.3-bin-2.6.tgz
+https://downloads.mesosphere.com/spark/assets/spark-2.0.0.tgz
+https://downloads.mesosphere.com/spark/assets/spark-2.0.1.tgz

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,18 @@
 {
     "cli_version": "0.5.19",
-    "spark_uri": "https://downloads.mesosphere.com/spark/assets/spark-2.0.1.tgz"
+    "spark_version": "1.6.3",
+    "default_spark_dist": {
+        "hadoop_version": "2.6",
+        "uri": "https://downloads.mesosphere.com/spark/assets/spark-1.6.3-bin-2.6.tgz"
+    },
+    "spark_dist": [
+        {
+            "hadoop_version": "2.4",
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-1.6.3-bin-2.4.tgz"
+        },
+        {
+            "hadoop_version": "2.6",
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-1.6.3-bin-2.6.tgz"
+        }
+    ]
 }

--- a/package/config.json
+++ b/package/config.json
@@ -44,8 +44,13 @@
                 },
                 "spark-dist-uri": {
                     "type": "string",
-                    "description": "Spark distribution URI.  The DCOS Spark CLI will fetch this Spark distribution.  This variable has no effect on the Spark distribution running the dispatcher or the drivers.  The Docker image running this Marathon app contains that distribution.",
+                    "description": "Spark distribution URI.  This is only used to run spark-submit on your local machine.  The DCOS Spark CLI will fetch this Spark distribution.  This variable has no effect on the Spark distribution running the dispatcher, drivers, nor executors.  If you want to customize the Spark build used in the jobs themselves, configure service.docker-image.",
                     "default": "{{spark-dist-uri}}"
+                },
+                "docker-image": {
+                    "type": "string",
+                    "description": "The docker image used to run the dispatcher, drivers, and executors.  If, for example, you need a Spark built with a specific Hadoop version, set this variable to one of the images here: https://hub.docker.com/r/mesosphere/spark/tags/",
+                    "default": "{{docker-image}}"
                 },
                 "log-level": {
                     "type": "string",


### PR DESCRIPTION
This makes it so the spark-release job will publish a version of Spark for each hadoop profile (2.4, 2.6, 2.7).

It also makes it so the spark-build-release job will publish a docker image for each hadoop profile.  We still only publish one DC/OS package per release, but the user can customize the DC/OS package with a different docker image via `service.docker-image`.