### PR TITLE
Setup permissions for hdfs role

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -64,6 +64,7 @@ setup_permissions() {
     if [ "$SECURITY" = "strict" ]; then
         # custom configuration to enable auth stuff:
         ${COMMONS_TOOLS_DIR}/setup_permissions.sh nobody "*" # spark's default service.role
+        ${COMMONS_TOOLS_DIR}/setup_permissions.sh nobody hdfs-role
     fi
 }
 


### PR DESCRIPTION
In strict mode, call setup_permissions.sh for hdfs.