### PR TITLE
[Spark-483] Add Kerberos principal and secret-based key tab to the CLI, also update libmesos in Dockerfile

### DIFF
--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -30,30 +30,23 @@ fi
 # But this fails now due to MESOS-6391, so I'm setting it to /tmp
 MESOS_DIRECTORY=/tmp
 
-echo "-->printing env"
-env
-echo "-->printing user"
-whoami
+echo "spark-env: Printing environment" >&2
+env >&2
+echo "spark-env: User: $(whoami)" >&2
 
-echo "decoding secrets"
 for f in $MESOS_SANDBOX/*.base64 ; do
-    echo "decoding $f"
+    echo "decoding $f" >&2
     secret=$(basename ${f} .base64)
     cat $f | base64 -d > ${secret}
     cat ${secret}
 done
 
 if [[ -n "${KRB5_CONFIG_BASE64}" ]]; then
-    echo "-->copying krb config from $KRB5_CONFIG_BASE64 to /etc/"
+    echo "spark-env: Copying krb config from $KRB5_CONFIG_BASE64 to /etc/" >&2
     echo "${KRB5_CONFIG_BASE64}" | base64 -d > /etc/krb5.conf
-    echo "-->copied"
 else
-    echo "-->No kerberos KDC config found"
+    echo "spark-env: No kerberos KDC config found" >2
 fi
-
-
-
-#[ -f "${MESOS_SANDBOX}/krb5.conf" ] && echo "found krb5.conf, moving to /etc/" && cp "${MESOS_SANDBOX}/krb5.conf" /etc/ && KRB5_CONFIG=/etc/krb5.conf
 
 # Options read when launching programs locally with
 # ./bin/run-example or ./bin/spark-submit

--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -14,7 +14,7 @@ mkdir -p "${HADOOP_CONF_DIR}"
 
 cd $MESOS_SANDBOX
 
-MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
+MESOS_NATIVE_JAVA_LIBRARY=/opt/mesosphere/libmesos-bundle/lib/libmesos.so
 
 # For non-CNI, tell the Spark driver to bind to LIBPROCESS_IP
 #

--- a/conf/spark-env.sh
+++ b/conf/spark-env.sh
@@ -30,6 +30,31 @@ fi
 # But this fails now due to MESOS-6391, so I'm setting it to /tmp
 MESOS_DIRECTORY=/tmp
 
+echo "-->printing env"
+env
+echo "-->printing user"
+whoami
+
+echo "decoding secrets"
+for f in $MESOS_SANDBOX/*.base64 ; do
+    echo "decoding $f"
+    secret=$(basename ${f} .base64)
+    cat $f | base64 -d > ${secret}
+    cat ${secret}
+done
+
+if [[ -n "${KRB5_CONFIG_BASE64}" ]]; then
+    echo "-->copying krb config from $KRB5_CONFIG_BASE64 to /etc/"
+    echo "${KRB5_CONFIG_BASE64}" | base64 -d > /etc/krb5.conf
+    echo "-->copied"
+else
+    echo "-->No kerberos KDC config found"
+fi
+
+
+
+#[ -f "${MESOS_SANDBOX}/krb5.conf" ] && echo "found krb5.conf, moving to /etc/" && cp "${MESOS_SANDBOX}/krb5.conf" /etc/ && KRB5_CONFIG=/etc/krb5.conf
+
 # Options read when launching programs locally with
 # ./bin/run-example or ./bin/spark-submit
 # - HADOOP_CONF_DIR, to point Spark towards Hadoop configuration files

--- a/dispatcher/cli/Makefile
+++ b/dispatcher/cli/Makefile
@@ -1,5 +1,4 @@
-#all: env test packages
-all: test packages
+all: env test packages
 
 clean:
 	bin/clean.sh

--- a/dispatcher/cli/Makefile
+++ b/dispatcher/cli/Makefile
@@ -1,5 +1,4 @@
-#all: env test packages
-all: packages
+all: env test packages
 
 clean:
 	bin/clean.sh

--- a/dispatcher/cli/Makefile
+++ b/dispatcher/cli/Makefile
@@ -1,4 +1,5 @@
-all: env test packages
+#all: env test packages
+all: packages
 
 clean:
 	bin/clean.sh

--- a/dispatcher/cli/dcos_spark/cli.py
+++ b/dispatcher/cli/dcos_spark/cli.py
@@ -8,6 +8,7 @@ Usage:
     dcos spark run --help
     dcos spark run --submit-args=<spark-args>
                    [--dcos-space=<dcos_space>]
+                   [--keytab-secret-path=<keytab_secret>]
                    [--docker-image=<docker-image>]
                    [--verbose]
     dcos spark status <submissionId> [--verbose]

--- a/dispatcher/cli/dcos_spark/spark_submit.py
+++ b/dispatcher/cli/dcos_spark/spark_submit.py
@@ -158,7 +158,7 @@ def format_kerberos_args(args):
     def check_args():
         if (args[constants.KERBEROS_PRINCIPAL_ARG] is None and
                 args[constants.KEYTAB_SECRET_PATH_ARG] is None):
-            return None  # No Kerberos args
+            return False  # No Kerberos args
         if args[constants.KERBEROS_PRINCIPAL_ARG] is not None:
             if args[constants.KEYTAB_SECRET_PATH_ARG] is None:
                 print("Missing {} argument for keytab "

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,9 @@
 # docker build -t spark:git-`git rev-parse --short HEAD` .
 
 # Basing from Mesos image so the Mesos native library is present.
-FROM mesosphere/mesos-modules-private:dcos-ee-mesos-modules-1.8.5-rc2
-MAINTAINER Michael Gummelt <mgummelt@mesosphere.io>
+#FROM mesosphere/mesos-modules-private:dcos-ee-mesos-modules-1.8.5-rc2
+FROM ubuntu:14.04
+MAINTAINER Michael Gummelt <mgummelt@mesosphere.io>, Arthur Rand <arand@mesosphere.io>
 
 # Set environment variables.
 ENV DEBIAN_FRONTEND "noninteractive"
@@ -37,13 +38,21 @@ RUN apt-get update && \
     apt-get install -y curl
 RUN apt-get install -y r-base
 
-RUN cd /usr/lib/jvm && \
+RUN mkdir -p /opt/mesosphere/ && \
+    cd /opt/mesosphere && \
+    curl -L -O https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz && \
+    tar zxf libmesos-bundle-1.10-1.4-63e0814.tar.gz && \
+    rm libmesos-bundle-1.10-1.4-63e0814.tar.gz
+
+RUN mkdir -p /usr/lib/jvm/ && \
+    cd /usr/lib/jvm && \
     curl -L -O https://downloads.mesosphere.com/java/jre-8u112-linux-x64-jce-unlimited.tar.gz && \
     tar zxf jre-8u112-linux-x64-jce-unlimited.tar.gz && \
     rm jre-8u112-linux-x64-jce-unlimited.tar.gz
 
 ENV JAVA_HOME /usr/lib/jvm/jre1.8.0_112
-ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
+ENV MESOS_NATIVE_JAVA_LIBRARY /opt/mesosphere/libmesos-bundle/lib/libmesos.so
+ENV LD_LIBRARY_PATH /opt/mesosphere/libmesos-bundle/lib/
 ENV HADOOP_CONF_DIR /etc/hadoop
 
 RUN mkdir /etc/hadoop

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@
 # docker build -t spark:git-`git rev-parse --short HEAD` .
 
 # Basing from Mesos image so the Mesos native library is present.
-#FROM mesosphere/mesos-modules-private:dcos-ee-mesos-modules-1.8.5-rc2
 FROM ubuntu:14.04
 MAINTAINER Michael Gummelt <mgummelt@mesosphere.io>, Arthur Rand <arand@mesosphere.io>
 

--- a/docker/runit/init.sh
+++ b/docker/runit/init.sh
@@ -65,6 +65,7 @@ if [[ -f hdfs-site.xml && -f core-site.xml ]]; then
 fi
 
 # Move kerberos config file, as specified by security.kerberos.krb5conf, into place.
+# this only effects the krb5.conf file for the dispatcher
 if [[ -n "${SPARK_MESOS_KRB5_CONF_BASE64}" ]]; then
     echo "${SPARK_MESOS_KRB5_CONF_BASE64}" | base64 -d > /etc/krb5.conf
 fi

--- a/docker/runit/init.sh
+++ b/docker/runit/init.sh
@@ -65,7 +65,7 @@ if [[ -f hdfs-site.xml && -f core-site.xml ]]; then
 fi
 
 # Move kerberos config file, as specified by security.kerberos.krb5conf, into place.
-# this only effects the krb5.conf file for the dispatcher
+# this only affects the krb5.conf file for the dispatcher
 if [[ -n "${SPARK_MESOS_KRB5_CONF_BASE64}" ]]; then
     echo "${SPARK_MESOS_KRB5_CONF_BASE64}" | base64 -d > /etc/krb5.conf
 fi

--- a/docs/hdfs.md
+++ b/docs/hdfs.md
@@ -79,6 +79,12 @@ Submit the job with the keytab:
     dcos spark run --kerberos-principal=user@REALM --keytab-secret-path=<secret_path> \
     --submit-args=" ... "
 
+### TGT Authentication
+
+Submit the job with the ticket:
+```$bash
+    dcos spark run --kerberos-principal user@REALM --submit-args="--tgt <ticket-file-path> ..."
+```
 
 **Note:** These credentials are security-critical. We highly recommended configuring SSL encryption between the Spark components when accessing Kerberos-secured HDFS clusters. See the Security section for information on how to do this.
 

--- a/docs/hdfs.md
+++ b/docs/hdfs.md
@@ -76,13 +76,9 @@ Keytabs are valid infinitely, while tickets can expire. Especially for long-runn
 
 Submit the job with the keytab:
 
-    dcos spark run --submit-args="--principal user@REALM --keytab <keytab-file-path>..."
+    dcos spark run --kerberos-principal=user@REALM --keytab-secret-path=<secret_path> \
+    --submit-args=" ... "
 
-### TGT Authentication
-
-Submit the job with the ticket:
-
-    dcos spark run --principal user@REALM --tgt <ticket-file-path>
 
 **Note:** These credentials are security-critical. We highly recommended configuring SSL encryption between the Spark components when accessing Kerberos-secured HDFS clusters. See the Security section for information on how to do this.
 


### PR DESCRIPTION
Add `--kerberos-principal` and `--keytab-secret-path` to the CLI, the former must match the key table in the secret indicated by the latter. Tested manually against a kerberized HDFS cluster. 

Todo:
- [x] add flags for secrets and kerberos principal
- [x] test against 1.10 file-based secrets
- [x] test against 1.10 environment based secrets
~test against 1.9 file-based secrets~
