### PR TITLE
Fix Spark Dispatcher's image config

### DIFF
--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -54,7 +54,12 @@
     "container": {
         "type": "DOCKER",
         "docker": {
+{{#service.docker-image}}
+            "image": "{{service.docker-image}}",
+{{/service.docker-image}}
+{{^service.docker-image}}
             "image": "{{resource.assets.container.docker.spark_docker}}",
+{{/service.docker-image}}
             "network": "HOST",
 {{#service.user}}
             "parameters": [


### PR DESCRIPTION
The property service.docker-image in config.json is not used. This is a nice property which helps people use a spark image other than the one provided already by Mesosphere.
Tested by deriving an image:

FROM mesosphere/spark:1.1.0-2.1.1-hadoop-2.6
ADD mesos-cluster-dispatcher.properties /opt/spark/dist/conf/mesos-cluster-dispatcher.properties
WORKDIR /opt/spark/dist