### PR TITLE
Update marathon.json.mustache

### DIFF
--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -93,7 +93,6 @@
 {{#hdfs.config-url}}
         "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
 {{/hdfs.config-url}}
-        "SPARK_URI": "{{service.spark-dist-uri}}",
         "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "DCOS_SERVICE_PORT_INDEX": "2",


### PR DESCRIPTION
Remove `service.spark-dist-uri` no longer present in `config.json`.

@ArtRand following the discussion on Slack. I wasn't sure if this should be removed.

Please review.