### PR TITLE
fix logging

### DIFF
--- a/docker/runit/service/spark/run
+++ b/docker/runit/service/spark/run
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-exec 2>&1
+#exec 2>&1
 
 SPARK_DIST_PATH=/opt/spark/dist
 


### PR DESCRIPTION
I am proposing to disable the stdout redirection as it interferes with the dispatcher's log output.
In the future we need to extend the log4j setup to write to a rolling file and this should be written to the sandbox (we don't have access to the container due to the use of UCR anyway). 

Right now I only get log messages coming from mesos or spark-env.sh, but no dispatcher messages.
```
I1012 20:07:14.064692 24365 fetcher.cpp:533] Fetcher Info: {"cache_directory":"\/tmp\/mesos\/fetch\/root","items":[{"action":"BYPASS_CACHE","uri":{"cache":false,"executable":false,"extract":false,"value":"http:\/\/api.hdfs.marathon.l4lb.thisdcos.directory\/v1\/endpoints\/hdfs-site.xml"}},{"action":"BYPASS_CACHE","uri":{"cache":false,"executable":false,"extract":false,"value":"http:\/\/api.hdfs.marathon.l4lb.thisdcos.directory\/v1\/endpoints\/core-site.xml"}}],"sandbox_directory":"\/var\/lib\/mesos\/slave\/slaves\/ef36c175-7650-49d9-9471-ba53386a0feb-S1\/frameworks\/ef36c175-7650-49d9-9471-ba53386a0feb-0001\/executors\/spark.f04339b1-af88-11e7-8086-ca36fc5d83f0\/runs\/df8ef856-b894-46da-8bb5-e1e74c0ef198","user":"root"}
I1012 20:07:14.068871 24365 fetcher.cpp:444] Fetching URI 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/hdfs-site.xml'
I1012 20:07:14.068893 24365 fetcher.cpp:285] Fetching directly into the sandbox directory
I1012 20:07:14.068953 24365 fetcher.cpp:222] Fetching URI 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/hdfs-site.xml'
I1012 20:07:14.068985 24365 fetcher.cpp:165] Downloading resource from 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/hdfs-site.xml' to '/var/lib/mesos/slave/slaves/ef36c175-7650-49d9-9471-ba53386a0feb-S1/frameworks/ef36c175-7650-49d9-9471-ba53386a0feb-0001/executors/spark.f04339b1-af88-11e7-8086-ca36fc5d83f0/runs/df8ef856-b894-46da-8bb5-e1e74c0ef198/hdfs-site.xml'
I1012 20:07:14.077198 24365 fetcher.cpp:582] Fetched 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/hdfs-site.xml' to '/var/lib/mesos/slave/slaves/ef36c175-7650-49d9-9471-ba53386a0feb-S1/frameworks/ef36c175-7650-49d9-9471-ba53386a0feb-0001/executors/spark.f04339b1-af88-11e7-8086-ca36fc5d83f0/runs/df8ef856-b894-46da-8bb5-e1e74c0ef198/hdfs-site.xml'
I1012 20:07:14.077220 24365 fetcher.cpp:444] Fetching URI 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/core-site.xml'
I1012 20:07:14.077234 24365 fetcher.cpp:285] Fetching directly into the sandbox directory
I1012 20:07:14.077251 24365 fetcher.cpp:222] Fetching URI 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/core-site.xml'
I1012 20:07:14.077265 24365 fetcher.cpp:165] Downloading resource from 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/core-site.xml' to '/var/lib/mesos/slave/slaves/ef36c175-7650-49d9-9471-ba53386a0feb-S1/frameworks/ef36c175-7650-49d9-9471-ba53386a0feb-0001/executors/spark.f04339b1-af88-11e7-8086-ca36fc5d83f0/runs/df8ef856-b894-46da-8bb5-e1e74c0ef198/core-site.xml'
I1012 20:07:14.082762 24365 fetcher.cpp:582] Fetched 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints/core-site.xml' to '/var/lib/mesos/slave/slaves/ef36c175-7650-49d9-9471-ba53386a0feb-S1/frameworks/ef36c175-7650-49d9-9471-ba53386a0feb-0001/executors/spark.f04339b1-af88-11e7-8086-ca36fc5d83f0/runs/df8ef856-b894-46da-8bb5-e1e74c0ef198/core-site.xml'
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1012 20:08:11.007628 24555 openssl.cpp:476] Failed SSL connections will be downgraded to a non-SSL socket
I1012 20:08:11.007743 24555 openssl.cpp:498] CA directory path unspecified! NOTE: Set CA directory path with LIBPROCESS_SSL_CA_DIR=<dirpath>
I1012 20:08:11.007761 24555 openssl.cpp:503] Will not verify peer certificate!
NOTE: Set LIBPROCESS_SSL_VERIFY_CERT=1 to enable peer certificate verification
I1012 20:08:11.007776 24555 openssl.cpp:509] Will only verify peer certificate if presented!
NOTE: Set LIBPROCESS_SSL_REQUIRE_CERT=1 to require peer certificate verification
W1012 20:08:11.008144 24555 process.cpp:1201] Failed SSL connections will be downgraded to a non-SSL socket
I1012 20:08:11.010829 24555 exec.cpp:162] Version: 1.4.0
I1012 20:08:11.025364 24569 exec.cpp:237] Executor registered on agent ef36c175-7650-49d9-9471-ba53386a0feb-S1
I1012 20:08:11.026310 24573 executor.cpp:120] Registered docker executor on 10.0.2.167
I1012 20:08:11.026563 24570 executor.cpp:160] Starting task spark.f04339b1-af88-11e7-8086-ca36fc5d83f0
+ export DISPATCHER_PORT=25533
+ DISPATCHER_PORT=25533
+ export DISPATCHER_UI_PORT=25534
+ DISPATCHER_UI_PORT=25534
+ export SPARK_PROXY_PORT=25535
+ SPARK_PROXY_PORT=25535
+ SCHEME=http
+ OTHER_SCHEME=https
+ [[ '' == true ]]
+ export DISPATCHER_UI_WEB_PROXY_BASE=/service/spark
+ DISPATCHER_UI_WEB_PROXY_BASE=/service/spark
+ grep -v '#https#' /etc/nginx/conf.d/spark.conf.template
+ sed s,#http#,,
+ sed -i 's,<PORT>,25535,' /etc/nginx/conf.d/spark.conf
+ sed -i 's,<DISPATCHER_URL>,http://10.0.2.167:25533,' /etc/nginx/conf.d/spark.conf
+ sed -i 's,<DISPATCHER_UI_URL>,http://10.0.2.167:25534,' /etc/nginx/conf.d/spark.conf
+ sed -i 's,<PROTOCOL>,,' /etc/nginx/conf.d/spark.conf
+ [[ '' == true ]]
+ [[ -f hdfs-site.xml ]]
+ [[ -n W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKZG5zX2xvb2t1cF9yZWFsbSA9IHRydWUKZG5zX2xvb2t1cF9rZGMgPSB0cnVlCnVkcF9wcmVmZXJlbmNlX2xpbWl0ID0gMQoKW3JlYWxtc10KICBMT0NBTCA9IHsKICAgIGtkYyA9IDEwLjAuMTAuMjo4OAogIH0KCltkb21haW5fcmVhbG1dCiAgLmhkZnMuZGNvcyA9IExPQ0FMCiAgaGRmcy5kY29zID0gTE9DQUwK ]]
+ echo W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKZG5zX2xvb2t1cF9yZWFsbSA9IHRydWUKZG5zX2xvb2t1cF9rZGMgPSB0cnVlCnVkcF9wcmVmZXJlbmNlX2xpbWl0ID0gMQoKW3JlYWxtc10KICBMT0NBTCA9IHsKICAgIGtkYyA9IDEwLjAuMTAuMjo4OAogIH0KCltkb21haW5fcmVhbG1dCiAgLmhkZnMuZGNvcyA9IExPQ0FMCiAgaGRmcy5kY29zID0gTE9DQUwK
+ base64 -d
+ exec runsvdir -P /etc/service
+ + mkdir -p /mnt/mesos/sandbox/nginx
mkdir -p /mnt/mesos/sandbox/spark
+ exec svlogd /mnt/mesos/sandbox/nginx
+ exec
+ exec svlogd /mnt/mesos/sandbox/spark
```