### PR TITLE
Update the spark distribution to 2.2.0-2 and update the key tab props to plural 

### DIFF
--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -233,9 +233,9 @@ func prepareBase64Secret(secretPath string, isEncoded bool) string {
 }
 
 func addArgsForFileBasedSecret(args *sparkArgs, secretPath, property string) {
-	args.properties["spark.mesos.driver.secret.name"] = secretPath
+	args.properties["spark.mesos.driver.secret.names"] = secretPath
 	args.properties[property] = prepareBase64Secret(secretPath, false)
-	args.properties["spark.mesos.driver.secret.filename"] = prepareBase64Secret(secretPath, true)
+	args.properties["spark.mesos.driver.secret.filenames"] = prepareBase64Secret(secretPath, true)
 }
 
 func setupKerberosAuthArgs(args *sparkArgs) error {
@@ -249,9 +249,9 @@ func setupKerberosAuthArgs(args *sparkArgs) error {
 		return nil
 	}
 	if args.tgtSecretValue != "" {  // using secret by value
-		args.properties["spark.mesos.driver.secret.value"] = args.tgtSecretValue
+		args.properties["spark.mesos.driver.secret.values"] = args.tgtSecretValue
 		args.properties["spark.mesos.driverEnv.KRB5CCNAME"] = "tgt"
-		args.properties["spark.mesos.driver.secret.filename"] = "tgt.base64"
+		args.properties["spark.mesos.driver.secret.filenames"] = "tgt.base64"
 		return nil
 	}
 	return errors.New(fmt.Sprintf("Unable to add Kerberos args, got args %s", args))

--- a/manifest.json
+++ b/manifest.json
@@ -3,16 +3,16 @@
     "spark_version": "2.2.0",
     "default_spark_dist": {
         "hadoop_version": "2.6",
-        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-1-bin-2.6.tgz"
+        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-2-bin-2.6.tgz"
     },
     "spark_dist": [
         {
             "hadoop_version": "2.6",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-1-bin-2.6.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-2-bin-2.6.tgz"
         },
         {
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-1-bin-2.7.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.2.0-2-bin-2.7.tgz"
         }
     ]
 }

--- a/tests/resources/secrets-opts.txt
+++ b/tests/resources/secrets-opts.txt
@@ -1,3 +1,3 @@
-spark.mesos.containerizer               mesos
-spark.mesos.driver.secret.name          secret
-spark.mesos.driver.secret.filename      secret_file
+spark.mesos.containerizer                mesos
+spark.mesos.driver.secret.names          secret
+spark.mesos.driver.secret.filenames      secret_file


### PR DESCRIPTION
Published distribution from [tag](https://github.com/mesosphere/spark/tree/custom-2.2.0-2) and updated manifest. Also fixed CLI `spark.mesos.driver.secret.name` -> `spark.mesos.driver.secret.names` (required in new version). 