### PR TITLE
[SPARK-570] CLI does not allow long strings of options, e.g. spark.driver.extraJavaOpts

### DIFF
--- a/cli/dcos-spark/cli_test.go
+++ b/cli/dcos-spark/cli_test.go
@@ -2,50 +2,73 @@ package main
 
 import (
     "testing"
-    "log"
+	"strings"
 )
 
 // test spaces
 func TestCleanUpSubmitArgs(t *testing.T) {
-  _, args := sparkSubmitArgSetup()
-  inputArgs := "--conf    spark.app.name=kerberosStreaming   --conf spark.cores.max=8"
-  submitArgs, _ := cleanUpSubmitArgs(inputArgs, args.boolVals)
-    if "--conf=spark.app.name=kerberosStreaming" != submitArgs[0] {
-       t.Errorf("Failed to reduce spaces while cleaning submit args.")
-    }
+	_, args := sparkSubmitArgSetup()
+	inputArgs := "--conf    spark.app.name=kerberosStreaming   --conf spark.cores.max=8"
+	submitArgs, _ := cleanUpSubmitArgs(inputArgs, args.boolVals)
+	if "--conf=spark.app.name=kerberosStreaming" != submitArgs[0] {
+		t.Errorf("Failed to reduce spaces while cleaning submit args.")
+	}
 
-    if "--conf=spark.cores.max=8" != submitArgs[1] {
-       t.Errorf("Failed to reduce spaces while cleaning submit args.")
-    }
+	if "--conf=spark.cores.max=8" != submitArgs[1] {
+		t.Errorf("Failed to reduce spaces while cleaning submit args.")
+	}
 }
 
 // test scopts pattern for app args when have full submit args
 func TestScoptAppArgs(t *testing.T) {
-  _, args := sparkSubmitArgSetup()
-  inputArgs := `--driver-cores 1 --conf spark.cores.max=1 --driver-memory 512M
-  --class org.apache.spark.examples.SparkPi http://spark-example.jar --input1 value1 --input2 value2`
-  submitArgs, appFlags := cleanUpSubmitArgs(inputArgs, args.boolVals)
+	_, args := sparkSubmitArgSetup()
+  	inputArgs := `--driver-cores 1 --conf spark.cores.max=1 --driver-memory 512M
+  	--class org.apache.spark.examples.SparkPi http://spark-example.jar --input1 value1 --input2 value2`
+  	submitArgs, appFlags := cleanUpSubmitArgs(inputArgs, args.boolVals)
 
-  if "--input1" != appFlags[0] {
-     t.Errorf("Failed to parse app args.")
-  }
-  if "value1" != appFlags[1] {
-     t.Errorf("Failed to parse app args.")
-  }
+  	if "--input1" != appFlags[0] {
+  		t.Errorf("Failed to parse app args.")
+	}
+	if "value1" != appFlags[1] {
+		t.Errorf("Failed to parse app args.")
+	}
 
-  if "--driver-memory=512M" != submitArgs[2] {
-     t.Errorf("Failed to parse submit args..")
-  }
-  if "http://spark-example.jar" != submitArgs[4] {
-     t.Errorf("Failed to parse submit args..")
-  }
+	if "--driver-memory=512M" != submitArgs[2] {
+		t.Errorf("Failed to parse submit args..")
+  	}
+  	if "http://spark-example.jar" != submitArgs[4] {
+  		t.Errorf("Failed to parse submit args..")
+  		}
 }
 
-// test spaces
+
+func testLongArgInternal(inputArgs string, t *testing.T) {
+	_, args := sparkSubmitArgSetup()
+
+	submitargs, _ := cleanUpSubmitArgs(inputArgs, args.boolVals)
+	if len(submitargs) != 2 {
+		t.Errorf("Failed to parse %s, should have 2 args, got %s", inputArgs, len(submitargs))
+	}
+
+	java_options_arg := submitargs[0]
+
+	if !strings.Contains(java_options_arg, "-Djava.something=somethingelse") {
+		t.Errorf("Failed to correctly parse first java option")
+	}
+
+	if !strings.Contains(java_options_arg, "-Djava.parameter=setting") {
+		t.Errorf("Failed to correctly parse second java option")
+	}
+}
+
+// test long args
 func TestStringLongArgs(t *testing.T) {
-    _, args := sparkSubmitArgSetup()
-    log.Printf("WOAH")
-    inputArgs := "--driver-java-options='-Djava.something=somethingelse -Djava.parameter=setting'  --conf spark.cores.max=8"
-    cleanUpSubmitArgs(inputArgs, args.boolVals)
-
+	inputArgs := "--driver-java-options '-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
+	inputArgs = "--conf spark.driver.extraJavaOptions='-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, t)
+	inputArgs = "--executor-java-options '-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, t)
+	inputArgs = "--conf spark.executor.extraJavaOptions='-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, t)
 }
+

--- a/cli/dcos-spark/cli_test.go
+++ b/cli/dcos-spark/cli_test.go
@@ -11,11 +11,11 @@ func TestCleanUpSubmitArgs(t *testing.T) {
 	inputArgs := "--conf    spark.app.name=kerberosStreaming   --conf spark.cores.max=8"
 	submitArgs, _ := cleanUpSubmitArgs(inputArgs, args.boolVals)
 	if "--conf=spark.app.name=kerberosStreaming" != submitArgs[0] {
-		t.Errorf("Failed to reduce spaces while cleaning submit args.")
+		t.Error("Failed to reduce spaces while cleaning submit args.")
 	}
 
 	if "--conf=spark.cores.max=8" != submitArgs[1] {
-		t.Errorf("Failed to reduce spaces while cleaning submit args.")
+		t.Error("Failed to reduce spaces while cleaning submit args.")
 	}
 }
 
@@ -27,17 +27,17 @@ func TestScoptAppArgs(t *testing.T) {
   	submitArgs, appFlags := cleanUpSubmitArgs(inputArgs, args.boolVals)
 
   	if "--input1" != appFlags[0] {
-  		t.Errorf("Failed to parse app args.")
+  		t.Error("Failed to parse app args.")
 	}
 	if "value1" != appFlags[1] {
-		t.Errorf("Failed to parse app args.")
+		t.Error("Failed to parse app args.")
 	}
 
 	if "--driver-memory=512M" != submitArgs[2] {
-		t.Errorf("Failed to parse submit args..")
+		t.Error("Failed to parse submit args..")
   	}
   	if "http://spark-example.jar" != submitArgs[4] {
-  		t.Errorf("Failed to parse submit args..")
+  		t.Error("Failed to parse submit args..")
   		}
 }
 
@@ -52,12 +52,17 @@ func testLongArgInternal(inputArgs string, t *testing.T) {
 
 	java_options_arg := submitargs[0]
 
+
 	if !strings.Contains(java_options_arg, "-Djava.something=somethingelse") {
-		t.Errorf("Failed to correctly parse first java option")
+		t.Error("Failed to correctly parse first java option")
+	}
+
+	if strings.Contains(java_options_arg, "'") {
+		t.Errorf("Failed to strip single quotes from args %s", java_options_arg)
 	}
 
 	if !strings.Contains(java_options_arg, "-Djava.parameter=setting") {
-		t.Errorf("Failed to correctly parse second java option")
+		t.Error("Failed to correctly parse second java option")
 	}
 }
 

--- a/cli/dcos-spark/cli_test.go
+++ b/cli/dcos-spark/cli_test.go
@@ -42,38 +42,37 @@ func TestScoptAppArgs(t *testing.T) {
 }
 
 
-func testLongArgInternal(inputArgs string, t *testing.T) {
-	_, args := sparkSubmitArgSetup()
-
+func testLongArgInternal(inputArgs string, expectedArgs []string, t *testing.T) {
+	_, args := sparkSubmitArgSetup()  // setup
 	submitargs, _ := cleanUpSubmitArgs(inputArgs, args.boolVals)
-	if len(submitargs) != 2 {
+	if len(submitargs) != 2 {  // should have 1 arg that's all the java options and one that's the spark cores config
 		t.Errorf("Failed to parse %s, should have 2 args, got %s", inputArgs, len(submitargs))
 	}
-
 	java_options_arg := submitargs[0]
-
-
-	if !strings.Contains(java_options_arg, "-Djava.something=somethingelse") {
-		t.Error("Failed to correctly parse first java option")
-	}
-
-	if strings.Contains(java_options_arg, "'") {
-		t.Errorf("Failed to strip single quotes from args %s", java_options_arg)
-	}
-
-	if !strings.Contains(java_options_arg, "-Djava.parameter=setting") {
-		t.Error("Failed to correctly parse second java option")
+	for i, a := range expectedArgs {
+		if !strings.Contains(java_options_arg, a) {
+			t.Errorf("Expected to find %s at index %d", a, i)
+		}
 	}
 }
 
 // test long args
 func TestStringLongArgs(t *testing.T) {
-	inputArgs := "--driver-java-options '-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
-	inputArgs = "--conf spark.driver.extraJavaOptions='-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
-	testLongArgInternal(inputArgs, t)
-	inputArgs = "--executor-java-options '-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
-	testLongArgInternal(inputArgs, t)
-	inputArgs = "--conf spark.executor.extraJavaOptions='-Djava.something=somethingelse -Djava.parameter=setting' --conf spark.cores.max=8"
-	testLongArgInternal(inputArgs, t)
-}
+	java_options := []string{"-Djava.firstConfig=firstSetting", "-Djava.secondConfig=secondSetting"}
+	inputArgs := "--driver-java-options '-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
+	inputArgs = "--driver-java-options='-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
+	inputArgs = "--conf spark.driver.extraJavaOptions='-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
+	inputArgs = "--executor-java-options '-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
+	inputArgs = "--conf spark.executor.extraJavaOptions='-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
 
+	java_options = append(java_options, "-Djava.thirdConfig=thirdSetting")
+	inputArgs = "--driver-java-option='-Djava.firstConfig=firstSetting -Djava.secondConfig=secondSetting -Djava.thirdConfig=thirdSetting' --conf spark.cores.max=8"
+	testLongArgInternal(inputArgs, java_options, t)
+
+
+}

--- a/cli/dcos-spark/cli_test.go
+++ b/cli/dcos-spark/cli_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+    "testing"
+    "log"
+)
 
 // test spaces
 func TestCleanUpSubmitArgs(t *testing.T) {
@@ -36,4 +39,13 @@ func TestScoptAppArgs(t *testing.T) {
   if "http://spark-example.jar" != submitArgs[4] {
      t.Errorf("Failed to parse submit args..")
   }
+}
+
+// test spaces
+func TestStringLongArgs(t *testing.T) {
+    _, args := sparkSubmitArgSetup()
+    log.Printf("WOAH")
+    inputArgs := "--driver-java-options='-Djava.something=somethingelse -Djava.parameter=setting'  --conf spark.cores.max=8"
+    cleanUpSubmitArgs(inputArgs, args.boolVals)
+
 }

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -357,17 +357,15 @@ ARGLOOP:
 					continue ARGLOOP
 				}
 			}
-			// merge this --key against the following val to get --key=val
-			if strings.HasPrefix(arg, "'") {
-				arg = strings.TrimPrefix(arg, "'")
-			}
 
+			// if this is the beginning of a string of args e.g. '-Djava.option=setting -Djava.paramter=nonsense'
+			// we want to remove the leading single quote. Also remove internal quotes when the arg == --conf or some
+			// other named configuration
+			// e.g.: next = spark.driver.extraJavaOptions='-Djava.something=somethingelse
+			// arg =  --conf
+			arg = strings.TrimPrefix(arg, "'")
 			next := args[i + 1]
-
-			if strings.Contains(next, "'") {
-				next = strings.Replace(next, "'", "", -1)
-			}
-
+			next = strings.Replace(next, "'", "", -1)  // remove internal quotes
 			argsEquals = append(argsEquals, arg + "=" + next)
 			i += 2
 		} else if strings.HasSuffix(arg, "'") {

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -3,14 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/mesosphere/dcos-commons/cli/client"
 	"github.com/mesosphere/dcos-commons/cli/config"
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -300,7 +298,7 @@ func parseApplicationFile(args *sparkArgs) error {
 
 func cleanUpSubmitArgs(argsStr string, boolVals []*sparkVal) ([]string, []string) {
 
-  // collapse two or more spaces to one.
+    // collapse two or more spaces to one.
 	argsCompacted := collapseSpacesPattern.ReplaceAllString(argsStr, " ")
 	// clean up any instances of shell-style escaped newlines: "arg1\\narg2" => "arg1 arg2"
 	argsCleaned := strings.TrimSpace(backslashNewlinePattern.ReplaceAllLiteralString(argsCompacted, " "))
@@ -345,7 +343,7 @@ ARGLOOP:
 		// 2. we start with "--"
 		// 3. we don't already contain "=" (already joined)
 		// 4. we aren't a boolean value (no val to join)
-		if i < len(args)-1 && strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") {
+		if i < len(args)-1 && strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") && strings.HasSuffix(arg, "'") {
 			// check for boolean:
 			for _, boolVal := range boolVals {
 				if boolVal.flagName == arg[2:] {
@@ -434,6 +432,12 @@ func appendToProperty(propValue, toAppend string, args *sparkArgs) {
 		args.properties[propValue] += "," + toAppend
 	}
 }
+
+func splitCleanedArgString(argsString string) []string {
+	log.Printf("Got args %s", argsString)
+	return strings.Split(argsString, " ")
+}
+
 
 func buildSubmitJson(cmd *SparkCommand) (string, error) {
 	// first, import any values in the provided properties file (space separated "key val")

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -435,20 +435,6 @@ func appendToProperty(propValue, toAppend string, args *sparkArgs) {
 	}
 }
 
-func getBase64Content(path string) string {
-	log.Printf("Opening file %s", path)
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var encodebuf bytes.Buffer
-	encoder := base64.NewEncoder(base64.StdEncoding, &encodebuf)
-	encoder.Write(data)
-	encoder.Close() // must be called before returning string to ensure flush
-	return encodebuf.String()
-}
-
 func buildSubmitJson(cmd *SparkCommand) (string, error) {
 	// first, import any values in the provided properties file (space separated "key val")
 	// then map applicable envvars


### PR DESCRIPTION
It's common that someone wants to set multiple java options `-Djava.setting=parameter`. Right now we only let one setting at a time, and extra arguments starting with `-D` will result in an unknown argument error. In the CLI _and_ `spark-submit` if the same configuration is set multiple times only the last setting is taken - we retain this functionality. We use single quotes `'` to designate the start of a string of arguments. 

Example:
```bash
dcos spark run --submit-args="\
...
--conf spark.driver.extraJavaOptions='-Djava.something=somethingElse -Djava.middleConfig=middleSetting -Djava.parameter=setting' \
--conf spark.executor.extraJavaOptions='-Djava.something=somethingElse -Djava.parameter=setting' \
...
```

or 

```bash
dcos spark run --submit-args="\
--driver-java-options='-Djava.something=somethingelse -Djava.parameter=setting' \
...
```

