### PR TITLE
[SPARK-585] Configurable deployment of Dispatcher on UCR

### DIFF
--- a/universe/config.json
+++ b/universe/config.json
@@ -55,6 +55,11 @@
                 "spark-history-server-url": {
                     "type": "string",
                     "description": "URL of The Spark History Server (e.g. http://<dcos_url>/service/spark-history"
+                },
+                "UCR_containerizer": {
+                    "type": "boolean",
+                    "description": "Launch the Dispatcher using the Universal Container Runtime (UCR)",
+                    "default": false
                 }
             }
         },

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -3,7 +3,7 @@
     "cpus": {{service.cpus}},
     "mem": {{service.mem}},
     "cmd": "/sbin/init.sh",
-    "user": "nobody",
+    "user": "{{service.user}}",
     "env": {
 {{#security.kerberos.krb5conf}}
         "SPARK_MESOS_KRB5_CONF_BASE64": "{{security.kerberos.krb5conf}}",

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -75,18 +75,43 @@
         }
     ],
 
+{{#service.UCR_containerizer}}
     "container": {
-        "type": "MESOS",
-        "docker": {
-{{#service.docker-image}}
-            "image": "{{service.docker-image}}",
-{{/service.docker-image}}
-{{^service.docker-image}}
-            "image": "{{resource.assets.container.docker.spark_docker}}",
-{{/service.docker-image}}
-        "forcePullImage": true
-      }
+    "type": "MESOS",
+    "docker": {
+    {{#service.docker-image}}
+        "image": "{{service.docker-image}}",
+    {{/service.docker-image}}
+    {{^service.docker-image}}
+        "image": "{{resource.assets.container.docker.spark_docker}}",
+    {{/service.docker-image}}
+    "forcePullImage": true
+    }
     },
+{{/service.UCR_containerizer}}
+{{^service.UCR_containerizer}}
+    "container": {
+    "type": "DOCKER",
+    "docker": {
+    {{#service.docker-image}}
+        "image": "{{service.docker-image}}",
+    {{/service.docker-image}}
+    {{^service.docker-image}}
+        "image": "{{resource.assets.container.docker.spark_docker}}",
+    {{/service.docker-image}}
+    "network": "HOST",
+    {{#service.user}}
+        "parameters": [
+        {
+        "key": "user",
+        "value": "{{service.user}}"
+        }
+        ],
+    {{/service.user}}
+    "forcePullImage": true
+    }
+    },
+{{/service.UCR_containerizer}}
 
     "healthChecks": [
         {

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -3,6 +3,7 @@
     "cpus": {{service.cpus}},
     "mem": {{service.mem}},
     "cmd": "/sbin/init.sh",
+    "user": "nobody",
     "env": {
 {{#security.kerberos.krb5conf}}
         "SPARK_MESOS_KRB5_CONF_BASE64": "{{security.kerberos.krb5conf}}",
@@ -28,7 +29,8 @@
 {{#service.spark-history-server-url}}
         "SPARK_HISTORY_SERVER_URL": "{{service.spark-history-server-url}}",
 {{/service.spark-history-server-url}}
-
+        "JAVA_HOME": "/usr/lib/jvm/jre1.8.0_131",
+        "LD_LIBRARY_PATH": "/opt/mesosphere/lib:/opt/mesosphere/libmesos-bundle/lib:/usr/lib",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
         "SPARK_USER": "{{service.user}}",
@@ -46,13 +48,35 @@
     },
 {{/service.service_account_secret}}
 
-    "ports": [
-        0,
-        0,
-        0
+    "portDefinitions": [
+        {
+            "port": 0,
+            "protocol": "tcp",
+            "name": "dispatcher",
+            "labels": {
+                "VIP_0": "spark-dispatcher:7077"
+            }
+        },
+        {
+            "port": 0,
+            "protocol": "tcp",
+            "name": "dispatcher-ui",
+            "labels": {
+                "VIP_1": "spark-dispatcher:4040"
+            }
+        },
+        {
+            "port": 0,
+            "protocol": "tcp",
+            "name": "dispatcher-proxy",
+            "labels": {
+                "VIP_2": "spark-dispatcher:80"
+            }
+        }
     ],
+
     "container": {
-        "type": "DOCKER",
+        "type": "MESOS",
         "docker": {
 {{#service.docker-image}}
             "image": "{{service.docker-image}}",
@@ -60,35 +84,31 @@
 {{^service.docker-image}}
             "image": "{{resource.assets.container.docker.spark_docker}}",
 {{/service.docker-image}}
-            "network": "HOST",
-{{#service.user}}
-            "parameters": [
-               {
-                 "key": "user",
-                 "value": "{{service.user}}"
-               }
-            ],
-{{/service.user}}
-            "forcePullImage": true
-        }
+        "forcePullImage": true
+      }
     },
+
     "healthChecks": [
         {
-{{#security.ssl.enabled}}
-            "protocol": "COMMAND",
-            "command": { "value": "curl -f -k https://$HOST:$PORT2/" },
-{{/security.ssl.enabled}}
-{{^security.ssl.enabled}}
-            "path": "/",
             "portIndex": 2,
-            "protocol": "HTTP",
-{{/security.ssl.enabled}}
+            "protocol": "MESOS_HTTP",
+            "path": "/",
             "gracePeriodSeconds": 5,
             "intervalSeconds": 60,
             "timeoutSeconds": 10,
             "maxConsecutiveFailures": 3
         }
     ],
+
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 0,
+        "maximumOverCapacity": 0
+    },
+
+    "unreachableStrategy": {
+        "expungeAfterSeconds": 0,
+        "inactiveAfterSeconds": 0
+    },
     "labels": {
 {{#hdfs.config-url}}
         "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",


### PR DESCRIPTION
Use the Mesos Universal Container Runtime (UCR) for the dispatcher. This allows `dcos task exec`. The health check and Spark signal handler also work better now. 