### PR TITLE
-Dspark args no longer supported

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -54,6 +54,10 @@ dispatcher use `dcos spark --name <dispatcher_app_id>`.
 * Spark driver now supports configurable failover_timeout. The default value is 0 when the configuration is not set.
 [SPARK-21456](https://issues.apache.org/jira/browse/SPARK-21456). 
 
+### Breaking change
+
+*  Spark CLI no longer supports -Dspark args.
+
 ## Version 1.0.9-2.1.0-1 
 
 - The history server has been removed from the "spark" package, and put into a dedicated "spark-history" package.


### PR DESCRIPTION
https://jira.mesosphere.com/browse/COPS-1865

I'm not sure I put this in the right right release.