### PR TITLE
[INFINITY-1212] Added "smoke" mark for smoke tests

### DIFF
--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -107,6 +107,7 @@ def setup_spark(kerberized_kafka, configure_security_spark):
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.skipif(not utils.kafka_enabled(), reason='KAFKA_ENABLED is false')
 def test_spark_and_kafka():
     kerberos_flag = "true" if KERBERIZED_KAFKA else "false"  # flag for using kerberized kafka given to app

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -46,6 +46,7 @@ def setup_spark(configure_security):
 
 @pytest.mark.xfail(utils.is_strict(), reason="Currently fails in strict mode")
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_jar(app_name=utils.SPARK_APP_NAME):
     master_url = ("https" if utils.is_strict() else "http") + "://leader.mesos:5050"
     spark_job_runner_args = '{} dcos \\"*\\" spark:only 2 --auth-token={}'.format(
@@ -60,6 +61,7 @@ def test_jar(app_name=utils.SPARK_APP_NAME):
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_rpc_auth():
     secret_name = "sparkauth"
 
@@ -85,6 +87,7 @@ def test_rpc_auth():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_sparkPi(app_name=utils.SPARK_APP_NAME):
     utils.run_tests(app_url=utils.SPARK_EXAMPLES,
                     app_args="100",
@@ -94,6 +97,7 @@ def test_sparkPi(app_name=utils.SPARK_APP_NAME):
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_python():
     python_script_path = os.path.join(THIS_DIR, 'jobs', 'python', 'pi_with_include.py')
     python_script_url = utils.upload_file(python_script_path)
@@ -106,6 +110,7 @@ def test_python():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_r():
     r_script_path = os.path.join(THIS_DIR, 'jobs', 'R', 'dataframe.R')
     r_script_url = utils.upload_file(r_script_path)
@@ -115,6 +120,7 @@ def test_r():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_cni():
     utils.run_tests(app_url=utils.SPARK_EXAMPLES,
                     app_args="",
@@ -125,6 +131,7 @@ def test_cni():
 
 #@pytest.mark.skip("Enable when SPARK-21694 is merged and released in DC/OS Spark")
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_cni_labels():
     driver_task_id = utils.submit_job(app_url=utils.SPARK_EXAMPLES,
                                       app_args="3000",   # Long enough to examine the Driver's & Executor's task infos
@@ -166,6 +173,7 @@ def _check_task_network_info(task):
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_s3():
     linecount_path = os.path.join(THIS_DIR, 'resources', 'linecount.txt')
     s3.upload_file(linecount_path)
@@ -220,6 +228,7 @@ def test_s3():
 # Skip DC/OS < 1.10, because it doesn't have adminrouter support for service groups.
 @pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_marathon_group():
     app_id = utils.FOLDERED_SPARK_APP_NAME
     options = {"service": {"name": app_id}}
@@ -231,6 +240,7 @@ def test_marathon_group():
 
 @pytest.mark.sanity
 @pytest.mark.secrets
+@pytest.mark.smoke
 def test_secrets():
     properties_file_path = os.path.join(THIS_DIR, "resources", "secrets-opts.txt")
     # Create secret
@@ -252,6 +262,7 @@ def test_secrets():
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_cli_multiple_spaces():
     utils.run_tests(app_url=utils.SPARK_EXAMPLES,
                     app_args="30",
@@ -264,6 +275,7 @@ def test_cli_multiple_spaces():
 @pytest.mark.skipif('shakedown.dcos_version_less_than("1.10")')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.smoke
 def test_driver_executor_tls():
     '''
     Put keystore and truststore as secrets in DC/OS secret store.


### PR DESCRIPTION
Added "smoke" mark for smoke tests, to be run against development versions of DC/OS. Includes all tests except HDFS ones, as HDFS take about 15 minutes to install/uninstall. The smoke test job, including cluster setup, should complete within an hour.