### PR TITLE
Add limits page for Spark (#286)

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,0 +1,34 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Limits
+menuWeight: 0
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+# DC/OS Spark Limits
+Mesosphere has scale-tested Spark on DC/OS by running a CPU-bound Monte Carlo application on the following hardware:
+
+## Cluster characteristics
+- 2560 cores total
+- 40 m4.16xlarge EC2 instances
+ 
+### Single executor per node:
+- 40 executors
+- Each executor: 64 cores, 2GB memory 
+- CPU utilization was > 90%, with majority of time spent in task computation
+
+### Multiple executors per node: 
+On a smaller, 1024-core, 16 node (m4.16xlarge) cluster, the following variations were tested:
+
+ | Executors | Time to Launch all Executors | Executors per Node |
+ | --------- | ---------------------------  | -----------------  |
+ | 82        | 7 s.                         | 16                 |
+ | 400       | 17 s.                        | 64                 |
+ | 820       | 28 s.                        | 64                 |
+
+In all tests, the application completed successfully. 


### PR DESCRIPTION
## Description
Addresses: [SPARK-691](https://jira.mesosphere.com/browse/SPARK-691)
This PR updates DC/OS Spark docs to report how much scale-testing we've done.

DC/OS Spark has been run on a 2.5K core cluster. 
The plan was to test on 10K cores but that was cost prohibitive.

## Urgency
- [x] Medium