### PR TITLE
configuration: normalize the config.json properties to be snake case

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: 
+navigationTitle:
 excerpt:
 title: Install and Customize
 menuWeight: 0
@@ -40,7 +40,7 @@ You can also [install Spark via the DC/OS GUI](https://docs.mesosphere.com/1.9/u
 
 ## Spark CLI
 You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
-the Spark CLI. 
+the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
 CLI.
@@ -90,7 +90,7 @@ configuration variables:
 ```json
 {
   "service": {
-    "docker-image": "<docker-image>"
+    "docker_image": "<docker_image>"
   }
 }
 ```
@@ -183,14 +183,14 @@ to follow these steps to install and run Spark.
     $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
     ```
 
-    For example: 
+    For example:
 
     ```bash
     dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
-    
+
     ```
 
-    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here.
 
     **Note** You can verify your new service account using the following command.
 
@@ -233,7 +233,7 @@ cluster:
     instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
     these code samples accordingly. We use `spark-service-role` to designate the role used below.
 
-Permissions can also be assigned through the UI. 
+Permissions can also be assigned through the UI.
 
 1.  Run the following to create the required permissions for Spark:
     ```bash
@@ -241,16 +241,16 @@ Permissions can also be assigned through the UI.
     $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
     ```
-    
+
     Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
 
     For example, continuing from above:
-    
+
     ```bash
     dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
     dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
-    
+
     ```
 
     Note that here we're using the service account `spark-principal` and the user `root`.
@@ -262,11 +262,11 @@ Permissions can also be assigned through the UI.
     dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
     ```
 
-## Install Spark with necessary configuration 
+## Install Spark with necessary configuration
 
 1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
     ```json
-    $ cat spark-strict-options.json 
+    $ cat spark-strict-options.json
     {
     "service": {
             "service_account": "<service-account-id>",
@@ -276,10 +276,10 @@ Permissions can also be assigned through the UI.
     }
     ```
 
-    A minimal example would be: 
+    A minimal example would be:
 
     ```json
-    { 
+    {
     "service": {
             "service_account": "spark-principal",
             "user": "root",
@@ -305,7 +305,7 @@ Permissions can also be assigned through the UI.
     --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
     ```
 
-If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable:
 
     ```bash
     $ dcos spark run --verbose --submit-args="\

--- a/history/package/config.json
+++ b/history/package/config.json
@@ -32,7 +32,7 @@
                     "type": "string",
                     "default": "root"
                 },
-                "docker-image": {
+                "docker_image": {
                     "description": "Docker image to run in.  See https://hub.docker.com/r/mesosphere/spark/tags/ for options.",
                     "type": "string",
                     "default": "{{default-docker-image}}"

--- a/history/package/marathon.json.mustache
+++ b/history/package/marathon.json.mustache
@@ -33,7 +33,7 @@
     "container": {
         "type": "MESOS",
         "docker": {
-            "image": "{{service.docker-image}}",
+            "image": "{{service.docker_image}}",
             "forcePullImage": true
         }
 {{#security.kerberos.keytab}}

--- a/universe/config.json
+++ b/universe/config.json
@@ -47,7 +47,7 @@
                     "description": "The docker image used to run the dispatcher, drivers, and executors.  If, for example, you need a Spark built with a specific Hadoop version, set this variable to one of the images here: https://hub.docker.com/r/mesosphere/spark/tags/",
                     "default": "{{docker-image}}"
                 },
-                "log-level": {
+                "log_level": {
                     "type": "string",
                     "description": "log4j log level for The Spark Dispatcher.  May be set to any valid log4j log level: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html",
                     "default": "INFO"

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -43,7 +43,7 @@
         "SPARK_DISPATCHER_MESOS_ROLE": "{{service.role}}",
         "SPARK_DISPATCHER_MESOS_PRINCIPAL": "{{service.service_account}}",
         "SPARK_DISPATCHER_MESOS_SECRET": "{{service.secret}}",
-        "SPARK_LOG_LEVEL": "{{service.log-level}}"
+        "SPARK_LOG_LEVEL": "{{service.log_level}}"
     },
 
 {{#service.service_account_secret}}
@@ -85,12 +85,12 @@
     "container": {
     "type": "MESOS",
     "docker": {
-    {{#service.docker-image}}
-        "image": "{{service.docker-image}}",
-    {{/service.docker-image}}
-    {{^service.docker-image}}
+    {{#service.docker_image}}
+        "image": "{{service.docker_image}}",
+    {{/service.docker_image}}
+    {{^service.docker_image}}
         "image": "{{resource.assets.container.docker.spark_docker}}",
-    {{/service.docker-image}}
+    {{/service.docker_image}}
     "forcePullImage": true
     }
     },
@@ -99,12 +99,12 @@
     "container": {
     "type": "DOCKER",
     "docker": {
-    {{#service.docker-image}}
-        "image": "{{service.docker-image}}",
-    {{/service.docker-image}}
-    {{^service.docker-image}}
+    {{#service.docker_image}}
+        "image": "{{service.docker_image}}",
+    {{/service.docker_image}}
+    {{^service.docker_image}}
         "image": "{{resource.assets.container.docker.spark_docker}}",
-    {{/service.docker-image}}
+    {{/service.docker_image}}
     "network": "HOST",
     {{#service.user}}
         "parameters": [

--- a/universe/resource.json
+++ b/universe/resource.json
@@ -2,7 +2,7 @@
     "assets": {
         "container": {
             "docker": {
-                "spark_docker": "{{docker-image}}"
+                "spark_docker": "{{docker_image}}"
             }
         }
     },


### PR DESCRIPTION
This PR aims to normalize the config.json properties to be snake_case, as the other properties. There is a mix right now.

This PR needs to be discussed with PRODUCT, it'll imply to change the existing `config.json` files.

