### PR TITLE
[COPS-3443] Make default docker image the one in resource.json

### DIFF
--- a/universe/config.json
+++ b/universe/config.json
@@ -44,8 +44,8 @@
                 },
                 "docker-image": {
                     "type": "string",
-                    "description": "The docker image used to run the dispatcher, drivers, and executors.  If, for example, you need a Spark built with a specific Hadoop version, set this variable to one of the images here: {{https-protocol}}hub.docker.com/r/mesosphere/spark/tags/",
-                    "default": "{{docker-image}}"
+                    "description": "The docker image used to run the dispatcher, drivers, and executors. If no image is specified {{docker-image}} will be used. If, for example, you need a Spark built with a specific Hadoop version, set this variable to one of the images here: {{https-protocol}}hub.docker.com/r/mesosphere/spark/tags/",
+                    "default": ""
                 },
                 "log-level": {
                     "type": "string",


### PR DESCRIPTION
Specifying the default docker image twice means that the default installation doesn't work on local universes.

This change removes the default from `config.json` which makes the value specified in `resource.json` the default. This does not change behaviour, but makes it easier to use Spark from a local universe.

The alternative would be extensive documentation changes.