### PR TITLE
[COPS-3550] Replace hardcoded VIP with service.name (#411)

### DIFF
--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -344,8 +344,8 @@ def test_unique_vips():
         utils.require_spark(spark1_service_name)
         utils.require_spark(spark2_service_name)
 
-        dispatcher1_ui = sdk_hosts.vip_host("marathon", "{}-dispatcher".format(spark1_service_name), 4040)
-        dispatcher2_ui = sdk_hosts.vip_host("marathon", "{}-dispatcher".format(spark2_service_name), 4040)
+        dispatcher1_ui = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark1_service_name), 4040)
+        dispatcher2_ui = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark2_service_name), 4040)
 
         # verify dispatcher-ui is reachable at VIP
         ok, _ = sdk_cmd.master_ssh("curl {}".format(dispatcher1_ui))

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -60,7 +60,7 @@
             "protocol": "tcp",
             "name": "dispatcher",
             "labels": {
-                "VIP_0": "spark-dispatcher:7077"
+                "VIP_0": "{{service.name}}-dispatcher:7077"
             }
         },
         {
@@ -68,7 +68,7 @@
             "protocol": "tcp",
             "name": "dispatcher-ui",
             "labels": {
-                "VIP_1": "spark-dispatcher:4040"
+                "VIP_1": "{{service.name}}-dispatcher:4040"
             }
         },
         {
@@ -76,7 +76,7 @@
             "protocol": "tcp",
             "name": "dispatcher-proxy",
             "labels": {
-                "VIP_2": "spark-dispatcher:80"
+                "VIP_2": "{{service.name}}-dispatcher:80"
             }
         }
     ],

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -60,7 +60,7 @@
             "protocol": "tcp",
             "name": "dispatcher",
             "labels": {
-                "VIP_0": "{{service.name}}-dispatcher:7077"
+                "VIP_0": "dispatcher.{{service.name}}:7077"
             }
         },
         {
@@ -68,7 +68,7 @@
             "protocol": "tcp",
             "name": "dispatcher-ui",
             "labels": {
-                "VIP_1": "{{service.name}}-dispatcher:4040"
+                "VIP_1": "dispatcher.{{service.name}}:4040"
             }
         },
         {
@@ -76,7 +76,7 @@
             "protocol": "tcp",
             "name": "dispatcher-proxy",
             "labels": {
-                "VIP_2": "{{service.name}}-dispatcher:80"
+                "VIP_2": "dispatcher.{{service.name}}:80"
             }
         }
     ],


### PR DESCRIPTION
## What changes were proposed in this pull request?
Backport of PR #411 && #414 

Replaces hardcoded VIP endpoint with `{{service.name}}`