### PR TITLE
[DCOS-47403] Spark 2.3.2 release version bump

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,16 +2,16 @@
     "spark_version": "2.3.2",
     "default_spark_dist": {
         "hadoop_version": "2.7",
-        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-SNAPSHOT-4-bin-2.7.7.tgz"
+        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-bin-2.7.7.tgz"
     },
     "spark_dist": [
         {
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-SNAPSHOT-4-bin-2.7.7.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-bin-2.7.7.tgz"
         },
         {
             "hadoop_version": "2.6",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-SNAPSHOT-4-bin-2.6.5.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.3.2-bin-2.6.5.tgz"
         }
     ]
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-47403](https://jira.mesosphere.com/browse/DCOS-47403)

Update Spark distribution version to the current release

## How were these changes tested?

* integration tests from current repo
* soak testing on DC/OS 1.10, 1.11, 1.11s, 1.12s, 1.13s

## Release Notes

N/A
