### PR TITLE
[DCOS-49117] spark-build-image-refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     openjdk-8-jdk \
     groff \
-    python-pip \
     python3 \
     python3-pip \
     r-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,26 @@
-FROM ubuntu:18.04
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#ubuntu:18.04 - linux; amd64
+#https://github.com/docker-library/repo-info/blob/master/repos/ubuntu/tag-details.md#ubuntu1804---linux-amd64
+FROM ubuntu@sha256:be159ff0e12a38fd2208022484bee14412680727ec992680b66cdead1ba76d19
+# Set environment variables for apt to be noninteractive
+ENV DEBIAN_FRONTEND "noninteractive"
+ENV DEBCONF_NONINTERACTIVE_SEEN "true"
+
 RUN apt-get update && apt-get install -y \
     bc \
     curl \
@@ -16,7 +38,7 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-pip \
     python3-venv \
-    python-software-properties \
+    r-base \
     software-properties-common \
     wget \
     zip && \
@@ -26,7 +48,6 @@ RUN add-apt-repository -y ppa:longsleep/golang-backports && apt-get update && ap
 # AWS CLI for uploading build artifacts
 RUN pip install awscli
 # Install dcos-launch to create clusters for integration testing
-RUN apt-get install -y python3-venv
 RUN wget https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch -O /usr/bin/dcos-launch
 RUN chmod +x /usr/bin/dcos-launch
 # shakedown and dcos-cli require this to output cleanly
@@ -35,17 +56,6 @@ ENV LANG=C.UTF-8
 # use an arbitrary path for temporary build artifacts
 ENV GOPATH=/go-tmp
 
-# Build R
-ENV R_VERSION=3.4.0
-ENV R_TGZ=R-${R_VERSION}.tar.gz
-RUN export PATH=/root/packages/bin:$PATH \
-  && cd /tmp \
-  && wget https://cran.r-project.org/src/base/R-3/${R_TGZ} \
-  && tar xf ${R_TGZ} \
-  && cd R-${R_VERSION}/ \
-  && ./configure --with-readline=no --with-x=no CPPFLAGS="-I/root/packages/include" LDFLAGS="-L/root/packages/lib" \
-  && make \
-  && make install
 
 RUN apt-get update && apt-get install -y apt-transport-https \
   && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,40 +22,24 @@ ENV DEBIAN_FRONTEND "noninteractive"
 ENV DEBCONF_NONINTERACTIVE_SEEN "true"
 
 RUN apt-get update && apt-get install -y \
-    bc \
     curl \
-    default-jdk \
-    gfortran \
-    git \
-    jq \
-    libbz2-dev \
-    liblzma-dev \
-    libcurl4-openssl-dev \
-    libpcre++-dev \
-    libssl-dev \
+    groff \
     python-pip \
     python3 \
-    python3-dev \
     python3-pip \
-    python3-venv \
     r-base \
     software-properties-common \
-    wget \
-    zip && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 # install go 1.7
 RUN add-apt-repository -y ppa:longsleep/golang-backports && apt-get update && apt-get install -y golang-go
 # AWS CLI for uploading build artifacts
-RUN pip install awscli
+RUN pip3 install awscli
 # Install dcos-launch to create clusters for integration testing
-RUN wget https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch -O /usr/bin/dcos-launch
-RUN chmod +x /usr/bin/dcos-launch
+RUN curl -L -o /usr/bin/dcos-launch https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch \
+    && chmod +x /usr/bin/dcos-launch
 # shakedown and dcos-cli require this to output cleanly
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-# use an arbitrary path for temporary build artifacts
-ENV GOPATH=/go-tmp
-
 
 RUN apt-get update && apt-get install -y apt-transport-https \
   && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,30 +20,34 @@ FROM ubuntu@sha256:be159ff0e12a38fd2208022484bee14412680727ec992680b66cdead1ba76
 # Set environment variables for apt to be noninteractive
 ENV DEBIAN_FRONTEND "noninteractive"
 ENV DEBCONF_NONINTERACTIVE_SEEN "true"
+# shakedown and dcos-cli require this to output cleanly
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update && apt-get install -y \
     curl \
+    openjdk-8-jdk \
     groff \
     python-pip \
     python3 \
     python3-pip \
     r-base \
     software-properties-common \
+    git \
     && rm -rf /var/lib/apt/lists/*
-# install go 1.7
-RUN add-apt-repository -y ppa:longsleep/golang-backports && apt-get update && apt-get install -y golang-go
+
+# install Go and SBT
+RUN add-apt-repository -y ppa:longsleep/golang-backports \
+    && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 \
+    && apt-get update && apt-get install -y \ 
+    sbt \
+    golang-go \
+    && rm -rf /var/lib/apt/lists/*
+
 # AWS CLI for uploading build artifacts
 RUN pip3 install awscli
 # Install dcos-launch to create clusters for integration testing
 RUN curl -L -o /usr/bin/dcos-launch https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch \
     && chmod +x /usr/bin/dcos-launch
-# shakedown and dcos-cli require this to output cleanly
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
 
-RUN apt-get update && apt-get install -y apt-transport-https \
-  && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 \
-  && apt-get update \
-  && apt-get install -y sbt \
-  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-49117](https://jira.mesosphere.com/browse/DCOS-49117)

- Switched base image from version to latest SHA tag,
- Installing R from Ubuntu package repository and removed build R from sources,
- Apache license added
- cleanup unused/irrelevant entries


## How were these changes tested?

Integration tests from this repo
