### PR TITLE
[DCOS-49281] Fix failing MWT streaming jobs

### DIFF
--- a/scale-tests/kafka_cassandra_streaming_test.py
+++ b/scale-tests/kafka_cassandra_streaming_test.py
@@ -53,7 +53,6 @@ COMMON_CONF = [
     "--conf", "spark.mesos.containerizer=mesos",
     "--conf", "spark.mesos.driver.failoverTimeout=30",
     "--conf", "spark.port.maxRetries=32",
-    "--conf", "spark.mesos.executor.home=/opt/spark/dist",
     "--conf", "spark.scheduler.maxRegisteredResourcesWaitingTime=2400s",
     "--conf", "spark.scheduler.minRegisteredResourcesRatio=1.0"
 ]

--- a/tests/jobs/scala/src/main/scala/GpuPi.scala
+++ b/tests/jobs/scala/src/main/scala/GpuPi.scala
@@ -1,16 +1,11 @@
-package com.databricks.spark.gpu.pi
-
-import jcuda.driver.CUdevice_attribute._
-import jcuda.driver.JCudaDriver._
-import java.util._
-import jcuda.driver._
-import jcuda.runtime._
-import jcuda.driver.CUmodule
 import jcuda._
-import jcuda.driver.CUdevice_attribute
+import jcuda.driver.JCudaDriver._
+import jcuda.driver.{CUmodule, _}
 
 object GpuPi {
-  val numThreads = 1024
+  val NumThreads = 1024
+  val OutputMemoryAllocation: Long = (Integer.SIZE * NumThreads).toLong
+
   def gpuPiMonteCarlo() : Array[Int] = {
     JCudaDriver.setExceptionsEnabled(true)
     cuInit(0)
@@ -21,23 +16,23 @@ object GpuPi {
     val module = new CUmodule
     CUresult.stringFor(cuModuleLoad(module, "/mnt/mesos/sandbox/PiCalc.ptx"))
     val function = new CUfunction()
-    cuModuleGetFunction(function, module, "piCalc");
+    cuModuleGetFunction(function, module, "piCalc")
     val deviceInput = new CUdeviceptr()
     val deviceOutput = new CUdeviceptr()
-    cuMemAlloc(deviceInput, Integer.SIZE);
-    cuMemAlloc(deviceOutput, Integer.SIZE * numThreads);
+    cuMemAlloc(deviceInput, Integer.SIZE)
+    cuMemAlloc(deviceOutput, OutputMemoryAllocation)
     val kernelParameters = Pointer.to(
       Pointer.to(deviceOutput)
     )
     cuLaunchKernel(function,
       1, 1, 1,           // Grid dimension
-      numThreads, 1, 1,  // Block dimension
+      NumThreads, 1, 1,  // Block dimension
       1, null,           // Shared memory size and stream
       kernelParameters, null // Kernel- and extra parameters
     )
     cuCtxSynchronize()
-    val hostOutput = new Array[Int](numThreads)
-    cuMemcpyDtoH(Pointer.to(hostOutput), deviceOutput, Integer.SIZE * numThreads)
+    val hostOutput = new Array[Int](NumThreads)
+    cuMemcpyDtoH(Pointer.to(hostOutput), deviceOutput, OutputMemoryAllocation)
     hostOutput
   }
 }

--- a/tests/jobs/scala/src/main/scala/GpuPiApp.scala
+++ b/tests/jobs/scala/src/main/scala/GpuPiApp.scala
@@ -1,4 +1,3 @@
-import com.databricks.spark.gpu.pi.GpuPi
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkConf
 import java.io._

--- a/tests/jobs/scala/src/main/scala/KafkaRandomFeeder.scala
+++ b/tests/jobs/scala/src/main/scala/KafkaRandomFeeder.scala
@@ -1,14 +1,39 @@
-import java.util.{Properties}
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{Executors, TimeUnit}
 
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
-import org.apache.log4j.{Level}
+import org.apache.log4j.Level
 import org.apache.spark.internal.Logging
+import org.apache.spark.streaming.scheduler.{StreamingListener, StreamingListenerReceiverStopped}
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 
 object KafkaRandomFeeder extends Logging {
+
+  sealed class ReceiverStreamingListener extends StreamingListener {
+    private var isStopped = false
+
+    override def onReceiverStopped(receiverStopped: StreamingListenerReceiverStopped): Unit = {
+      logInfo("Receiver stopped, shutting down Streaming Context")
+      isStopped = true
+    }
+
+    def receiverStopped: Boolean = isStopped
+  }
+
+  sealed class ContextReaper(receiverListener: ReceiverStreamingListener, ssc: StreamingContext) extends Runnable {
+    override def run(): Unit = {
+      if (receiverListener.receiverStopped) {
+        //'stopGracefully' to drain received messages into Kafka
+        ssc.stop(stopSparkContext = true, stopGracefully = true)
+      }
+    }
+  }
+
   def main(args: Array[String]): Unit = {
     KafkaCassandraStream.setStreamingLogLevels(Level.WARN)
 
+    //FIXME: shared parsing functionality should be generalized in a dedicated class
     val parser = KafkaCassandraStream.getParser(this.getClass.getSimpleName, true).parse(args, Config())
 
     if (parser.isEmpty) {
@@ -19,11 +44,34 @@ object KafkaRandomFeeder extends Logging {
     val config = parser.get
     println(s"Using config: $config")
 
+    //FIXME: shared functionality should be generalized in a dedicated class
     val spark = KafkaCassandraStream.createSparkSession(config)
-
     val streamingContext = new StreamingContext(spark.sparkContext, Seconds(config.batchSizeSeconds))
 
-    val stream = streamingContext.receiverStream(new RandomWordReceiver(config.wordsPerSecond, config.numberOfWords))
+    //Handling context monitoring and termination in a dedicated thread pool
+    val executorService = Executors.newScheduledThreadPool(1)
+    val receiverListener = new ReceiverStreamingListener
+    val contextReaper = new ContextReaper(receiverListener, streamingContext)
+
+    streamingContext.addStreamingListener(receiverListener)
+
+    /*
+    TODO:
+    in the long run, it makes sense to switch from Receiver approach to Driver-side publishing only
+    to get accurate finite results and simpler design (without reaper tasks, several thread pools etc).
+
+    Receiver is designed to be a long-running source without any control over the context lifecycle e.g. accept
+    data via socket. Trying to keep it manageable makes the code too complicated for the task of just
+    feeding Kafka with random data.
+
+    @see KerberizedKafkaProducer for an example of Driver-side only Kafka publishing
+    */
+    val wordCounter = new AtomicLong(config.numberOfWords)
+    val isInfiniteStream = config.numberOfWords == 0
+    val accumulator = streamingContext.sparkContext.longAccumulator("words_sent")
+    val randomWordReceiver = new RandomWordReceiver(config.wordsPerSecond, wordCounter, accumulator, infinite = isInfiniteStream)
+
+    val stream = streamingContext.receiverStream(randomWordReceiver)
 
     val kafkaProperties = getKafkaProperties(config.brokers, config.isKerberized)
     println(s"${kafkaProperties}")
@@ -36,7 +84,7 @@ object KafkaRandomFeeder extends Logging {
         println(s"Handling streamed RDD partition")
 
         partition.foreach { word =>
-          println(s"Writing ${word} to Kafka")
+          println(s"Writing $word to Kafka")
           val msg = new ProducerRecord[String, String](topic, null, word)
           producer.send(msg)
         }
@@ -45,10 +93,11 @@ object KafkaRandomFeeder extends Logging {
       }
     }
 
+    executorService.scheduleAtFixedRate(contextReaper, 0, 100, TimeUnit.MILLISECONDS)
     streamingContext.start()
     streamingContext.awaitTermination()
+    executorService.shutdown()
   }
-
 
   def getKafkaProperties(brokers : String, isKerberized: Boolean): Properties = {
     val props = new Properties()

--- a/tests/jobs/scala/src/main/scala/KafkaWordCount.scala
+++ b/tests/jobs/scala/src/main/scala/KafkaWordCount.scala
@@ -1,10 +1,8 @@
-import java.util.{Date}
-
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.log4j.{Level}
+import org.apache.log4j.Level
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.kafka010.{ConsumerStrategies, KafkaUtils, LocationStrategies}
 import org.apache.spark.streaming.{Seconds, StreamingContext}

--- a/tests/jobs/scala/src/main/scala/MockTaskRunner.scala
+++ b/tests/jobs/scala/src/main/scala/MockTaskRunner.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.SparkSession
   * Usage: MockTaskRunner [numTasks] [taskDurationSec]
   */
 object MockTaskRunner {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     if (args.length < 2) {
       println("Usage: MockTaskRunner [numTasks] [taskDurationSec]")
       System.exit(1)
@@ -20,11 +20,12 @@ object MockTaskRunner {
       .getOrCreate()
 
     val numTasks = args(0).toInt
-    val sleepSeconds = args(1).toInt
+    val sleepSeconds = args(1).toLong
+    val sleepMillis = sleepSeconds * 1000
 
     spark.sparkContext.parallelize(0 until numTasks, numTasks).foreachPartition{_ =>
       println(s"Sleeping for $sleepSeconds seconds")
-      Thread.sleep(sleepSeconds * 1000)
+      Thread.sleep(sleepMillis)
       println(s"Sleep finished")
     }
 

--- a/tests/jobs/scala/src/main/scala/ShuffleApp.scala
+++ b/tests/jobs/scala/src/main/scala/ShuffleApp.scala
@@ -9,7 +9,7 @@ import scala.util.Random
   * Usage: ShuffleApp [numMappers] [numKeys] [valueSize] [numReducers] [sleepBeforeShutdown]
   */
 object ShuffleApp {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val spark = SparkSession
       .builder
       .appName("Shuffle Test")
@@ -19,7 +19,7 @@ object ShuffleApp {
     val numKeys = if (args.length > 1) args(1).toInt else 1000
     val valSize = if (args.length > 2) args(2).toInt else 1000
     val numReducers = if (args.length > 3) args(3).toInt else numMappers
-    val sleepBeforeShutdown = if (args.length > 4) args(4).toInt else 0
+    val sleepBeforeShutdownMillis = if (args.length > 4) args(4).toLong * 1000 else 0
 
     val keyPairs = spark.sparkContext.parallelize(0 until numMappers, numMappers).flatMap { _ =>
       val random = new Random
@@ -43,7 +43,7 @@ object ShuffleApp {
 
     val groupsCount = keyPairs.groupByKey(numReducers).count()
     println(s"Groups count: $groupsCount")
-    Thread.sleep(sleepBeforeShutdown * 1000)
+    Thread.sleep(sleepBeforeShutdownMillis)
     spark.stop()
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-49281](https://jira.mesosphere.com/browse/DCOS-49281)

* removed problematic `spark.mesos.executor.home` config overrides
* cleaned up test applications code so there's no compiler warnings
* updated `KafkaRandomFeeder` and `RandomWordReceiver`:
  * implemented graceful context stop when a specified amount of words is published
  * introduced scheduled thread pool for rate-based message emission and better thread management
  * added atomic counters to avoid over- and under-delivery

## How were these changes tested?

* integration tests from this repo
* running manual tests with the following configuration:
```
dcos spark run --submit-args="\
    --conf spark.cores.max=2 \
    --conf spark.executor.cores=2 \
    --name KafkaProducer \
    --class KafkaRandomFeeder \
    --conf spark.mesos.containerizer=mesos \
    --conf spark.mesos.driver.failoverTimeout=30 \
    --conf spark.port.maxRetries=32 \
    --conf spark.scheduler.maxRegisteredResourcesWaitingTime=2400s \
    --conf spark.scheduler.minRegisteredResourcesRatio=1.0 \
    --conf spark.mesos.role=* \
    --conf spark.driver.memory=2g \
    http://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar \
    --appName KafkaProducer \
    --brokers kafka-0-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-1-broker.kafka.autoip.dcos.thisdcos.directory:1025,kafka-2-broker.kafka.autoip.dcos.thisdcos.directory:1025 \
    --topics test_topic \
    --numberOfWords 500 \
    --wordsPerSecond 10"
```
and verifying the amount of published messages by running `kafka-console-consumer.sh` inside a broker task on DCOS: `kafka-console-consumer.sh --zookeeper master.mesos:2181/dcos-service-kafka --from-beginning --topic test_topic`. 

NOTE: to run a consumer like that, one needs to set the environment after attaching to a broker task:
```
dcos task exec -ti <TID> bash

export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/)
export KAFKA_HOME=$(ls -d $MESOS_SANDBOX/kafka_*/)
export PATH=$PATH:$JAVA_HOME/bin:$KAFKA_HOME/bin
```

## Release Notes

N/A
