### PR TITLE
[DCOS-33733] Enable support of --packages flag in Spark CLI

### DIFF
--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -220,7 +220,9 @@ Args:
 	val.flag(submit).StringVar(&val.s)
 	args.stringVals = append(args.stringVals, val)
 
-	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of package names (i.e. maven coordinates) to be downloaded on the driver and executor classpaths.")
+	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of maven coordinates of jars to include "+
+                "on the driver and executor classpaths. Will search the local maven repo, then maven central and any additional remote "+
+                "repositories given by --repositories. The format for the coordinates should be groupId:artifactId:version")
         val.flag(submit).StringVar(&val.s)
         args.stringVals = append(args.stringVals, val)
 

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -221,6 +221,10 @@ Args:
 	val.flag(submit).StringVar(&val.s)
 	args.stringVals = append(args.stringVals, val)
 
+	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of colon-separated package names and versions to be downloaded on the driver and executor classpaths.")
+        val.flag(submit).StringVar(&val.s)
+        args.stringVals = append(args.stringVals, val)
+
 	val = newSparkVal("py-files", "spark.submit.pyFiles", "Add .py, .zip or .egg files to "+
 		"be distributed with your application. If you depend on multiple Python files we recommend packaging them "+
 		"into a .zip or .egg.")

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -220,7 +220,7 @@ Args:
 	val.flag(submit).StringVar(&val.s)
 	args.stringVals = append(args.stringVals, val)
 
-	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of package names to be downloaded on the driver and executor classpaths.")
+	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of package names (i.e. maven coordinates) to be downloaded on the driver and executor classpaths.")
         val.flag(submit).StringVar(&val.s)
         args.stringVals = append(args.stringVals, val)
 

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -22,6 +22,8 @@ var keyWhitespaceValPattern = regexp.MustCompile("(.+)\\s+(.+)")
 var backslashNewlinePattern = regexp.MustCompile("\\s*\\\\s*\\n\\s+")
 var collapseSpacesPattern = regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 
+const mesosSandboxPath = "/mnt/mesos/sandbox"
+
 type sparkVal struct {
 	flagName string
 	propName string
@@ -374,9 +376,9 @@ func processJarsFlag(args []string) []string {
 			}
 			// add --conf spark.driver.extraClassPaths=one.jar:two.jar
 			// add --conf spark.executor.extraClassPath=one.jar:two.jar
-			jarPaths := strings.Join(jarNames, ":/mnt/mesos/sandbox/")
-			newArgs = append(newArgs, "--conf", "spark.driver.extraClassPath=/mnt/mesos/sandbox/"+jarPaths)
-			newArgs = append(newArgs, "--conf", "spark.executor.extraClassPath=/mnt/mesos/sandbox/"+jarPaths)
+			jarPaths := strings.Join(jarNames, ":"+mesosSandboxPath+"/")
+			newArgs = append(newArgs, "--conf", "spark.driver.extraClassPath="+mesosSandboxPath+"/"+jarPaths)
+			newArgs = append(newArgs, "--conf", "spark.executor.extraClassPath="+mesosSandboxPath+"/"+jarPaths)
 			newArgs = append(newArgs, args[i+1:]...)
 			break
 		}
@@ -399,8 +401,8 @@ func processPackagesFlag(args []string) []string {
 				i++
 				newArgs = append(newArgs, args[:i+1]...)
 			}
-			// add --conf spark.jars.ivy=/mnt/mesos/sandbox/.ivy2
-			newArgs = append(newArgs, "--conf", "spark.jars.ivy=/mnt/mesos/sandbox/.ivy2")
+			// add --conf spark.jars.ivy=path/to/ivy_user_dir
+			newArgs = append(newArgs, "--conf", "spark.jars.ivy="+mesosSandboxPath+"/.ivy2")
 			newArgs = append(newArgs, args[i+1:]...)
 			break
 		}

--- a/cli/dcos-spark/submit_builder.go
+++ b/cli/dcos-spark/submit_builder.go
@@ -119,7 +119,6 @@ appears to be client mode only? doesn't seem to be used in POST submit call at a
 - proxyUser:              --proxy-user SOMENAME
 client mode only (downloads jars to local system, wouldn't work for POST call):
 - ivyRepoPath:            (spark.jars.ivy)
-- packages:               --packages maven,coordinates,for,jars (spark.jars.packages)
 - packagesExclusions:     --exclude-packages groupId:artifactId,toExclude:fromClasspath (spark.jars.excludes)
 - repositories:           --repositories additional.remote,repositories.to.search
 yarn only (note: principal/tgt/keytab are supported in patched spark):
@@ -221,7 +220,7 @@ Args:
 	val.flag(submit).StringVar(&val.s)
 	args.stringVals = append(args.stringVals, val)
 
-	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of colon-separated package names and versions to be downloaded on the driver and executor classpaths.")
+	val = newSparkVal("packages", "spark.jars.packages", "Comma-separated list of package names to be downloaded on the driver and executor classpaths.")
         val.flag(submit).StringVar(&val.s)
         args.stringVals = append(args.stringVals, val)
 

--- a/cli/dcos-spark/submit_builder_test.go
+++ b/cli/dcos-spark/submit_builder_test.go
@@ -21,7 +21,6 @@ const keytabPrefixed = "__dcos_base64__keytab"
 const keytab = "keytab"
 const sparkAuthSecret = "spark-auth-secret"
 const marathonAppId = "spark-app"
-const sparkPackages = "group.one.id:artifact-one-id:version.one,group.two.id:artifact-two-id:version.two"
 
 var marathonConfig = map[string]interface{}{"app": map[string]interface{}{"id": marathonAppId}}
 
@@ -366,6 +365,7 @@ func (suite *CliTestSuite) TestSaslSecret() {
 }
 
 func (suite *CliTestSuite) TestPackagesFlag() {
+	sparkPackages := "group.one.id:artifact-one-id:version.one,group.two.id:artifact-two-id:version.two"
 	inputArgs := fmt.Sprintf(
 		"--packages %s "+
 		"--class %s "+
@@ -374,28 +374,22 @@ func (suite *CliTestSuite) TestPackagesFlag() {
 	cmd := createCommand(inputArgs, image)
         payload, err := buildSubmitJson(&cmd, marathonConfig)
 
-        m := make(map[string]interface{})
+        jsonMap := make(map[string]interface{})
 
-        json.Unmarshal([]byte(payload), &m)
+        json.Unmarshal([]byte(payload), &jsonMap)
 
         if err != nil {
                 suite.T().Errorf("%s", err.Error())
         }
 
         stringProps := map[string]string{
-                "spark.mesos.task.labels":                    fmt.Sprintf("DCOS_SPACE:%s", marathonAppId),
-                "spark.ssl.noCertVerification":               "true",
-                "spark.executor.memory":                      "1G", // default
-                "spark.submit.deployMode":                    "cluster",
-                "spark.mesos.driver.labels":                  fmt.Sprintf("DCOS_SPACE:%s", marathonAppId),
-		"spark.jars.packages":                        sparkPackages,
-                "spark.jars":                                 appJar,
+		"spark.jars.packages": sparkPackages,
         }
 
-        v, ok := m["sparkProperties"].(map[string]interface{})
+        sparkProps, ok := jsonMap["sparkProperties"].(map[string]interface{})
         if !ok {
                 suite.T().Errorf("%+v", ok)
         }
 
-        suite.checkProps(v, stringProps)
+        suite.checkProps(sparkProps, stringProps)
 }

--- a/cli/dcos-spark/submit_builder_test.go
+++ b/cli/dcos-spark/submit_builder_test.go
@@ -21,7 +21,6 @@ const keytabPrefixed = "__dcos_base64__keytab"
 const keytab = "keytab"
 const sparkAuthSecret = "spark-auth-secret"
 const marathonAppId = "spark-app"
-const mesosSandbox = "/mnt/mesos/sandbox"
 
 var marathonConfig = map[string]interface{}{"app": map[string]interface{}{"id": marathonAppId}}
 
@@ -93,8 +92,8 @@ func (suite *CliTestSuite) TestProcessJarsFlag() {
 	expected := []string{"--conf=spark.cores.max=8",
 		"--jars=http://one.jar",
 		"--conf=spark.mesos.uris=http://one.jar",
-		"--conf=spark.driver.extraClassPath=" + mesosSandbox + "/one.jar",
-		"--conf=spark.executor.extraClassPath=" + mesosSandbox + "/one.jar",
+		"--conf=spark.driver.extraClassPath=" + mesosSandboxPath + "/one.jar",
+		"--conf=spark.executor.extraClassPath=" + mesosSandboxPath + "/one.jar",
 		"app/jars/main.jar"}
 	actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
 	assert.Equal(suite.T(), expected, actual)
@@ -106,8 +105,8 @@ func (suite *CliTestSuite) TestProcessMultiJarsFlag() {
 	expected := []string{"--conf=spark.cores.max=8",
 		"--jars=http://one.jar,http://two.jar",
 		"--conf=spark.mesos.uris=http://one.jar,http://two.jar",
-		"--conf=spark.driver.extraClassPath=" + mesosSandbox + "/one.jar:" + mesosSandbox + "/two.jar",
-		"--conf=spark.executor.extraClassPath=" + mesosSandbox + "/one.jar:" + mesosSandbox + "/two.jar",
+		"--conf=spark.driver.extraClassPath=" + mesosSandboxPath + "/one.jar:" + mesosSandboxPath + "/two.jar",
+		"--conf=spark.executor.extraClassPath=" + mesosSandboxPath + "/one.jar:" + mesosSandboxPath + "/two.jar",
 		"main.jar"}
 	actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
 	assert.Equal(suite.T(), expected, actual)
@@ -119,8 +118,8 @@ func (suite *CliTestSuite) TestProcessMultiJarsFlagWithSpace() {
 	expected := []string{"--conf=spark.cores.max=8",
 		"--jars=http://one.jar,http://two.jar",
 		"--conf=spark.mesos.uris=http://one.jar,http://two.jar",
-		"--conf=spark.driver.extraClassPath=" + mesosSandbox + "/one.jar:" + mesosSandbox + "/two.jar",
-		"--conf=spark.executor.extraClassPath=" + mesosSandbox + "/one.jar:" + mesosSandbox + "/two.jar",
+		"--conf=spark.driver.extraClassPath=" + mesosSandboxPath + "/one.jar:" + mesosSandboxPath + "/two.jar",
+		"--conf=spark.executor.extraClassPath=" + mesosSandboxPath + "/one.jar:" + mesosSandboxPath + "/two.jar",
 		"main.jar"}
 	actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
 	assert.Equal(suite.T(), expected, actual)
@@ -131,7 +130,7 @@ func (suite *CliTestSuite) TestProcessPackagesFlag() {
         inputArgs := "--conf spark.cores.max=8 --packages=groupid:artifactid:version app/packages/main.jar 100"
         expected := []string{"--conf=spark.cores.max=8",
                 "--packages=groupid:artifactid:version",
-                "--conf=spark.jars.ivy=" + mesosSandbox + "/.ivy2",
+                "--conf=spark.jars.ivy=" + mesosSandboxPath + "/.ivy2",
                 "app/packages/main.jar"}
         actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
         assert.Equal(suite.T(), expected, actual)
@@ -142,7 +141,7 @@ func (suite *CliTestSuite) TestProcessMultiPackagesFlag() {
         inputArgs := "--conf spark.cores.max=8 --packages=groupid1:artifactid1:version1,groupid2:artifactid2:version2 app/packages/main.jar 100"
         expected := []string{"--conf=spark.cores.max=8",
                 "--packages=groupid1:artifactid1:version1,groupid2:artifactid2:version2",
-                "--conf=spark.jars.ivy=" + mesosSandbox + "/.ivy2",
+                "--conf=spark.jars.ivy=" + mesosSandboxPath + "/.ivy2",
                 "app/packages/main.jar"}
         actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
         assert.Equal(suite.T(), expected, actual)
@@ -153,7 +152,7 @@ func (suite *CliTestSuite) TestProcessMultiPackagesFlagWithSpace() {
         inputArgs := "--conf spark.cores.max=8 --packages groupid1:artifactid1:version1,groupid2:artifactid2:version2 app/packages/main.jar 100"
         expected := []string{"--conf=spark.cores.max=8",
                 "--packages=groupid1:artifactid1:version1,groupid2:artifactid2:version2",
-                "--conf=spark.jars.ivy=" + mesosSandbox + "/.ivy2",
+                "--conf=spark.jars.ivy=" + mesosSandboxPath + "/.ivy2",
                 "app/packages/main.jar"}
         actual, _ := transformSubmitArgs(inputArgs, args.boolVals)
         assert.Equal(suite.T(), expected, actual)
@@ -418,7 +417,7 @@ func (suite *CliTestSuite) TestPackagesFlag() {
         }
 
         stringProps := map[string]string{
-		"spark.jars.ivy": mesosSandbox + "/.ivy2",
+		"spark.jars.ivy": mesosSandboxPath + "/.ivy2",
 		"spark.jars.packages": sparkPackages,
         }
 

--- a/tests/jobs/scala/README.md
+++ b/tests/jobs/scala/README.md
@@ -72,3 +72,25 @@ In the example above Spark Driver will launch 4 single-core executors (controlle
 properties). When all executors are up, 12000 unique keys will be generated 4 times i.e. each of 4 partitions will contain 
 the same set of keys which will then be grouped by 4 reducers. `sleepBeforeShutdown` parameter is needed in order to
 verify tasks' properties while they're running and avoid quick application termination. 
+
+## ProvidedPackages
+[ProvidedPackages](src/main/scala/ProvidedPackages.scala) adds number from 1 to `inputNum`, where the default value of `inputNum` is 10, and prints the sum. To perform the addition it is using the `guava` library, which would be marked as provided in the [build.sbt](build.sbt). The main aim of this class is to test the availability of the `guava` library in the classpath of driver as well as executors, without shifting it with the main application jar. This can be achieved by specifying `guava` package's maven coordinates in the `--packages` flag.
+
+Usage:
+
+```
+dcos spark run --submit-args="--class ProvidedPackages \
+https://s3.us-east-2.amazonaws.com/<S3 Bucket>/dcos-spark-scala-tests-assembly-<version>.jar inputNum"
+```
+
+Example:
+
+```
+dcos spark run --verbose --submit-args=" \
+--packages=com.google.guava:guava:23.0 \
+--class ProvidedPackages \
+https://s3.us-east-2.amazonaws.com/<S3 bucket>/dcos-spark-scala-tests-assembly-<version>.jar 20"
+
+```
+
+In the example above Spark will download the `guava` package in the classpath of driver as well as executors. The classpath will be decided by the `spark.jars.ivy` setting.

--- a/tests/jobs/scala/build.sbt
+++ b/tests/jobs/scala/build.sbt
@@ -16,7 +16,8 @@ lazy val root = (project in file("."))
       "com.github.scopt" %% "scopt" % "3.7.0",
       "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.7",
       "com.airbnb" % "kafka-statsd-metrics2" % "0.5.2+issue28" from "https://infinity-artifacts.s3.amazonaws.com/scale-tests/kafka-statsd-metrics2-0.5.2+issue28-20180612-8c1e3c4f3fa83.jar",
-      "com.datadoghq" % "java-dogstatsd-client" % "2.5"
+      "com.datadoghq" % "java-dogstatsd-client" % "2.5",
+      "com.google.guava" % "guava" % "23.0" % "provided"
     )
   )
 

--- a/tests/jobs/scala/build.sbt
+++ b/tests/jobs/scala/build.sbt
@@ -16,7 +16,6 @@ lazy val root = (project in file("."))
       "com.github.scopt" %% "scopt" % "3.7.0",
       "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.7",
       "com.airbnb" % "kafka-statsd-metrics2" % "0.5.2+issue28" from "https://infinity-artifacts.s3.amazonaws.com/scale-tests/kafka-statsd-metrics2-0.5.2+issue28-20180612-8c1e3c4f3fa83.jar",
-      "com.datadoghq" % "java-dogstatsd-client" % "2.5",
       "com.google.guava" % "guava" % "23.0" % "provided"
     )
   )

--- a/tests/jobs/scala/build.sbt
+++ b/tests/jobs/scala/build.sbt
@@ -16,6 +16,7 @@ lazy val root = (project in file("."))
       "com.github.scopt" %% "scopt" % "3.7.0",
       "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.7",
       "com.airbnb" % "kafka-statsd-metrics2" % "0.5.2+issue28" from "https://infinity-artifacts.s3.amazonaws.com/scale-tests/kafka-statsd-metrics2-0.5.2+issue28-20180612-8c1e3c4f3fa83.jar",
+      "com.datadoghq" % "java-dogstatsd-client" % "2.5",
       "com.google.guava" % "guava" % "23.0" % "provided"
     )
   )

--- a/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
+++ b/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
@@ -14,7 +14,7 @@ import com.google.common.base.Verify
 object ProvidedPackages {
     def main(args: Array[String]): Unit = {
         val appName = "ProvidedPackages"
-        println(s"Running $AppName\n")
+        println(s"Running $appName\n")
 
         var inputNumber = 10
         // Check argument is provided
@@ -30,7 +30,7 @@ object ProvidedPackages {
 	var driverSum = 0
 	(1 to inputNumber).foreach(driverSum += _)
 
-        val spark = SparkSession.builder.appName(AppName).getOrCreate()
+        val spark = SparkSession.builder.appName(appName).getOrCreate()
 
 	// Calculate the sum on the executor
         val executorSum = spark.sparkContext.parallelize(1 to inputNumber).reduce((x, y) => IntMath.checkedAdd(x, y))

--- a/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
+++ b/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
@@ -13,7 +13,7 @@ import com.google.common.base.Verify
   */ 
 object ProvidedPackages {
     def main(args: Array[String]): Unit = {
-        val AppName = "ProvidedPackages App"
+        val appName = "ProvidedPackages"
         println(s"Running $AppName\n")
 
         var inputNumber = 10
@@ -35,8 +35,8 @@ object ProvidedPackages {
 	// Calculate the sum on the executor
         val executorSum = spark.sparkContext.parallelize(1 to inputNumber).reduce((x, y) => IntMath.checkedAdd(x, y))
         
-        // Verify the both sum
+        // Verify both sums
         Verify.verify(driverSum == executorSum, "Sum of %s numbers on the executor (%s) is not equal to sum on the driver (%s)", inputNumber.toString, executorSum.toString, driverSum.toString)
-	println(s"The sum of $inputNumber numbers is $driverSum")
+	println(s"$driverSum")
     }
 }

--- a/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
+++ b/tests/jobs/scala/src/main/scala/ProvidedPackages.scala
@@ -1,0 +1,42 @@
+import org.apache.spark.sql.SparkSession
+import com.google.common.math.IntMath
+import com.google.common.base.Verify
+
+/**
+  * Application that outputs the sum of numbers from 1 to N.
+  * Specifically we want to test whether a package (e.g. guava) is available by specifying in the packages flag in submit-args.
+  * E.g. 
+  * dcos spark run --submit-args="\
+        --packages=com.google.guava:guava:23.0 \
+        --class ProvidedPackages \
+        <jar> number"
+  */ 
+object ProvidedPackages {
+    def main(args: Array[String]): Unit = {
+        val AppName = "ProvidedPackages App"
+        println(s"Running $AppName\n")
+
+        var inputNumber = 10
+        // Check argument is provided
+        if (args.length > 0) {
+	    try {
+	        inputNumber = args(0).toInt
+	    } catch {
+		case e: NumberFormatException => inputNumber = 10
+	    }
+        }
+
+	// Calculate the sum on the driver
+	var driverSum = 0
+	(1 to inputNumber).foreach(driverSum += _)
+
+        val spark = SparkSession.builder.appName(AppName).getOrCreate()
+
+	// Calculate the sum on the executor
+        val executorSum = spark.sparkContext.parallelize(1 to inputNumber).reduce((x, y) => IntMath.checkedAdd(x, y))
+        
+        // Verify the both sum
+        Verify.verify(driverSum == executorSum, "Sum of %s numbers on the executor (%s) is not equal to sum on the driver (%s)", inputNumber.toString, executorSum.toString, driverSum.toString)
+	println(s"The sum of $inputNumber numbers is $driverSum")
+    }
+}

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -175,6 +175,17 @@ def test_jars_flag(service_name=utils.SPARK_SERVICE_NAME):
         args=["--jars {}".format(uploadedJarUrl),
               "--class MultiConfs"])
 
+@pytest.mark.sanity
+def test_packages_flag(service_name=utils.SPARK_SERVICE_NAME):
+    utils.run_tests(
+        app_url=utils.dcos_test_jar_url(),
+        app_args="20",
+        expected_output="The sum of 20 numbers is 210",
+        service_name=service_name,
+        args=["--conf spark.mesos.containerizer=mesos",
+              "--packages com.google.guava:guava:23.0",
+              "--class ProvidedPackages"])
+
 
 @pytest.mark.sanity
 @pytest.mark.smoke

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -180,11 +180,9 @@ def test_packages_flag(service_name=utils.SPARK_SERVICE_NAME):
     utils.run_tests(
         app_url=utils.dcos_test_jar_url(),
         app_args="20",
-        expected_output="The sum of 20 numbers is 210",
+        expected_output="210",
         service_name=service_name,
-        args=["--conf spark.mesos.containerizer=mesos",
-              "--conf spark.jars.ivy=/mnt/mesos/sandbox/.ivy2",
-              "--packages com.google.guava:guava:23.0",
+        args=["--packages com.google.guava:guava:23.0",
               "--class ProvidedPackages"])
 
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -176,12 +176,11 @@ def test_jars_flag(service_name=utils.SPARK_SERVICE_NAME):
               "--class MultiConfs"])
 
 @pytest.mark.sanity
-def test_packages_flag(service_name=utils.SPARK_SERVICE_NAME):
+def test_packages_flag():
     utils.run_tests(
         app_url=utils.dcos_test_jar_url(),
         app_args="20",
         expected_output="210",
-        service_name=service_name,
         args=["--packages com.google.guava:guava:23.0",
               "--class ProvidedPackages"])
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -183,6 +183,7 @@ def test_packages_flag(service_name=utils.SPARK_SERVICE_NAME):
         expected_output="The sum of 20 numbers is 210",
         service_name=service_name,
         args=["--conf spark.mesos.containerizer=mesos",
+              "--conf spark.jars.ivy=/mnt/mesos/sandbox/.ivy2",
               "--packages com.google.guava:guava:23.0",
               "--class ProvidedPackages"])
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-33733](https://jira.mesosphere.com/browse/DCOS-33733)

* Spark CLI will support `--packages` flag in `submit-args` flag of `run` sub-command.
* While processing the `--packages` flag, It automatically sets `spark.jars.ivy` property to `/mnt/mesos/sandbox/.ivy2` as default location to download the jars.
* Unit Tests to verify setting of these properties: `spark.jars.packages=<maven_coordinates>` and `spark.jars.ivy=<ivy_user_dir>`.
* Integration test to verify that the mentioned packages in the flag is being downloaded in driver and executor.
* Added a custom class `ProvidedPackages`, to support the integration test.

## How were these changes tested?

* Unit Tests covering all the scenario of giving value to the flag and setting `spark.jars.ivy` property in the process.
* Running integration test `test_packages_flag`

## Release Notes

* Added support of `--packages` flag in Spark CLI