### PR TITLE
[DCOS-33745] fetched cli segfault fix from dcos-commons, added a check for 401 response code

### DIFF
--- a/cli/dcos-spark/main.go
+++ b/cli/dcos-spark/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	app := cli.New()
 	handleCommands(app)
+	client.SetCustomResponseCheck(checkForUnauthorized)
 	// Omit modname:
 	kingpin.MustParse(app.Parse(cli.GetArguments()))
 }
@@ -371,5 +372,14 @@ func checkSparkJSONResponse(responseJson map[string]interface{}) error {
 	if !successBool {
 		return errors.New("Spark returned success=false")
 	}
+	return nil
+}
+
+func checkForUnauthorized(response *http.Response, body []byte) error {
+	if (response.StatusCode == http.StatusUnauthorized) {
+		return fmt.Errorf("%s request to %s was not authorized. Make sure you are logged in.",
+			response.Request.Method, response.Request.URL)
+	}
+
 	return nil
 }

--- a/cli/dcos-spark/main_test.go
+++ b/cli/dcos-spark/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/mesosphere/dcos-commons/cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func createHttpResponseWithStatus(statusCode int, filename string) http.Response {
+	status := fmt.Sprintf("%v %s", statusCode, http.StatusText(statusCode))
+	var body io.ReadCloser
+	if filename != "" {
+		content, _ := ioutil.ReadFile(filename)
+		body = ioutil.NopCloser(bytes.NewBuffer(content))
+	}
+	return http.Response{StatusCode: statusCode, Status: status, Body: body}
+}
+
+func TestUnauthorizedResponseCustomCheck(t *testing.T) {
+	response := createHttpResponseWithStatus(http.StatusUnauthorized, "testdata/responses/unauthorized.html")
+	testMethod := "GET"
+	testUrl := "https://example.com/marathon/v2/apps/spark"
+	request, _ := http.NewRequest(testMethod, testUrl, bytes.NewReader(nil))
+	response.Request = request
+
+	client.SetCustomResponseCheck(checkForUnauthorized)
+	_, err := client.CheckHTTPResponse(&response, nil)
+
+	expectedErrorMessage := fmt.Sprintf("%s request to %s was not authorized. Make sure you are logged in.",
+		testMethod, testUrl)
+	assert.Equal(t, err.Error(), expectedErrorMessage)
+}

--- a/cli/dcos-spark/testdata/responses/unauthorized.html
+++ b/cli/dcos-spark/testdata/responses/unauthorized.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Unauthorized</title>
+    <noscript><meta http-equiv="refresh" content="5; url=/#/login"></noscript>
+    <script>
+        (function () {
+            var location = window.location;
+            location.href = "/#/login?redirect=" + encodeURIComponent(location.href);
+        }())
+    </script>
+</head>
+<body>
+<h1>Unauthorized</h1>
+</body>
+</html>

--- a/cli/dcos-spark/vendor/github.com/mesosphere/dcos-commons/cli/README.md
+++ b/cli/dcos-spark/vendor/github.com/mesosphere/dcos-commons/cli/README.md
@@ -36,12 +36,12 @@ cd sdk/cli/
 To run the compiled CLI (the example below uses Linux, pick the correct binary for your platform):
 
 ```bash
-./dcos-service-cli-linux hello-world -h
+./dcos-service-cli-linux helloworld -h
 ```
 
 ## Develop
 
-See the [default CLI module](../sdk/) for the default CLI module with no added commands. For an example of adding custom commands, see the [Kafka CLI module](../frameworks/kafka/cli).
+See the [default CLI module](../sdk/) for the default CLI module with no added commands. For an example of adding custom commands, see the [Kafka CLI module](https://github.com/mesosphere/dcos-kafka-service/tree/master/frameworks/kafka/cli).
 
 Like the example CLI modules above, your own code may access the CLI libraries provided here by importing `github.com/mesosphere/dcos-commons/cli`. Your CLI module implementation may pick and choose which standard commands should be included, while also implementing its own custom commands.
 
@@ -98,6 +98,6 @@ When installed, the module is executed as a regular binary by the DC/OS CLI, wit
 $ <exename> <modulename> [args]
 ```
 
-So for example, if someone called `dcos kafka broker list`, the `dcos-service-cli` CLI module would be run as `dcos-service-cli kafka broker list` by the DC/OS CLI.
+So for example, if someone called `dcos helloworld pod list`, the `dcos-service-cli` CLI module would be run as `dcos-service-cli helloworld pod list` by the DC/OS CLI.
 
-The inclusion of `modulename` (`kafka` in this example) as an argument allows reuse of a single CLI module build across multiple packages. In particular this is used by the default CLI build which is shared across most packages.
+The inclusion of `modulename` (`helloworld` in this example) as an argument allows reuse of a single CLI module build across multiple packages. In particular this is used by the default CLI build which is shared across most packages.

--- a/cli/dcos-spark/vendor/github.com/mesosphere/dcos-commons/cli/client/response.go
+++ b/cli/dcos-spark/vendor/github.com/mesosphere/dcos-commons/cli/client/response.go
@@ -29,6 +29,9 @@ func CheckHTTPResponse(response *http.Response, err error) ([]byte, error) {
 		err = err.(*url.Error).Err
 	}
 	if err != nil {
+		if response == nil {
+			return nil, fmt.Errorf("Encountered an empty response, with error: %s, retry the operation again later", err)
+		}
 		switch err.(type) {
 		case x509.UnknownAuthorityError:
 			// custom suggestions for a certificate error:

--- a/cli/dcos-spark/vendor/vendor.json
+++ b/cli/dcos-spark/vendor/vendor.json
@@ -21,34 +21,34 @@
 			"revisionTime": "2018-02-21T22:46:20Z"
 		},
 		{
-			"checksumSHA1": "kbCt1P08/QIAaOSjF/DTvflwsHQ=",
+			"checksumSHA1": "Zh/SIyV2CDUNz5g9qb2ScKGxwUU=",
 			"path": "github.com/mesosphere/dcos-commons/cli",
-			"revision": "c9970ca35751da5f26e8b57dc9fcbd6fc139c29b",
-			"revisionTime": "2018-04-24T03:33:12Z"
+			"revision": "0069656dc683bb0052199f440a019f23290eec11",
+			"revisionTime": "2019-04-10T07:35:29Z"
 		},
 		{
-			"checksumSHA1": "RtIxmUnHx4wIXNSZA/bMA3jo1ik=",
+			"checksumSHA1": "tm8cc4JRkETRI3tzM+Kvn2zkMD4=",
 			"path": "github.com/mesosphere/dcos-commons/cli/client",
-			"revision": "c9970ca35751da5f26e8b57dc9fcbd6fc139c29b",
-			"revisionTime": "2018-04-24T03:33:12Z"
+			"revision": "0069656dc683bb0052199f440a019f23290eec11",
+			"revisionTime": "2019-04-10T07:35:29Z"
 		},
 		{
 			"checksumSHA1": "QDiOJgnY42uMi15mdpWTQC+XWOE=",
 			"path": "github.com/mesosphere/dcos-commons/cli/commands",
-			"revision": "c9970ca35751da5f26e8b57dc9fcbd6fc139c29b",
-			"revisionTime": "2018-04-24T03:33:12Z"
+			"revision": "0069656dc683bb0052199f440a019f23290eec11",
+			"revisionTime": "2019-04-10T07:35:29Z"
 		},
 		{
 			"checksumSHA1": "y/MfA7he+pywk7ADfefLAHZJiWs=",
 			"path": "github.com/mesosphere/dcos-commons/cli/config",
-			"revision": "c9970ca35751da5f26e8b57dc9fcbd6fc139c29b",
-			"revisionTime": "2018-04-24T03:33:12Z"
+			"revision": "0069656dc683bb0052199f440a019f23290eec11",
+			"revisionTime": "2019-04-10T07:35:29Z"
 		},
 		{
 			"checksumSHA1": "Bes2UqmiEf0QOkK3QsieyNjfdSc=",
 			"path": "github.com/mesosphere/dcos-commons/cli/queries",
-			"revision": "c9970ca35751da5f26e8b57dc9fcbd6fc139c29b",
-			"revisionTime": "2018-04-24T03:33:12Z"
+			"revision": "0069656dc683bb0052199f440a019f23290eec11",
+			"revisionTime": "2019-04-10T07:35:29Z"
 		},
 		{
 			"checksumSHA1": "uEc9/1HbYGeK7wPStF6FmUlfzGE=",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-33745] - Unhelpful error message in CLI when not logged in (https://jira.mesosphere.com/browse/DCOS-33745)

- Updated vendored dependency on dcos-commons which includes a fix for segfault on empty responses (https://jira.mesosphere.com/browse/DCOS-42966 - Kubernetes CLI can segfault)
- Added a custom check for "401 Unauthorized" response, to print a more helpful error message 
`<HTTP Method> request to <URL> was not authorized. Make sure you are logged in.`
instead of 
`dcos-beta-spark: error: invalid character '<' looking for beginning of value, try --help`

## How were these changes tested?
- Manually tested
- Added a unit test for CLI change

## Release Notes
- [Bugfix] Improved error message in CLI when not logged into a cluster