### PR TITLE
[DCOS-41592] - Adds an integration test for Mesos labels support

### DIFF
--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -398,3 +398,16 @@ def test_task_stdout():
         assert stdout_file["size"] > 0, "stdout file should have content"
     finally:
         sdk_install.uninstall(utils.SPARK_PACKAGE_NAME, service_name)
+
+
+@pytest.mark.sanity
+def test_mesos_label_support():
+    driver_task_id = utils.submit_job(app_url=utils.SPARK_EXAMPLES,
+                                      app_args="150",
+                                      args=["--conf spark.cores.max=1",
+                                            "--conf spark.mesos.driver.labels=foo:bar", # pass a test label
+                                            "--class org.apache.spark.examples.SparkPi"])
+
+    driver_task_info = sdk_cmd._get_task_info(driver_task_id)
+    test_label_values = [label['value'] for label in driver_task_info['labels'] if label['key'] == 'foo']
+    assert 'bar' in test_label_values

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -68,8 +68,8 @@ def test_mesos_label_support():
                                             "--class org.apache.spark.examples.SparkPi"])
 
     driver_task_info = sdk_cmd._get_task_info(driver_task_id)
-    test_label_values = [label['value'] for label in driver_task_info['labels'] if label['key'] == 'foo']
-    assert 'bar' in test_label_values
+    expected = {'key': 'foo', 'value': 'bar'}
+    assert expected in driver_task_info['labels']
 
 
 def retry_if_false(result):

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -59,6 +59,19 @@ def test_task_not_lost():
     utils.check_job_output(driver_task_id, "Pi is roughly 3")
 
 
+@pytest.mark.sanity
+def test_mesos_label_support():
+    driver_task_id = utils.submit_job(app_url=utils.SPARK_EXAMPLES,
+                                      app_args="150",
+                                      args=["--conf spark.cores.max=1",
+                                            "--conf spark.mesos.driver.labels=foo:bar", # pass a test label
+                                            "--class org.apache.spark.examples.SparkPi"])
+
+    driver_task_info = sdk_cmd._get_task_info(driver_task_id)
+    test_label_values = [label['value'] for label in driver_task_info['labels'] if label['key'] == 'foo']
+    assert 'bar' in test_label_values
+
+
 def retry_if_false(result):
     return not result
 
@@ -398,16 +411,3 @@ def test_task_stdout():
         assert stdout_file["size"] > 0, "stdout file should have content"
     finally:
         sdk_install.uninstall(utils.SPARK_PACKAGE_NAME, service_name)
-
-
-@pytest.mark.sanity
-def test_mesos_label_support():
-    driver_task_id = utils.submit_job(app_url=utils.SPARK_EXAMPLES,
-                                      app_args="150",
-                                      args=["--conf spark.cores.max=1",
-                                            "--conf spark.mesos.driver.labels=foo:bar", # pass a test label
-                                            "--class org.apache.spark.examples.SparkPi"])
-
-    driver_task_info = sdk_cmd._get_task_info(driver_task_id)
-    test_label_values = [label['value'] for label in driver_task_info['labels'] if label['key'] == 'foo']
-    assert 'bar' in test_label_values


### PR DESCRIPTION
[DCOS-41592] - Adds an integration test for Mesos labels support in Spark

## What changes were proposed in this pull request?

Resolves [DCOS-41592] - [Integration Tests] Add Mesos labels support to the Spark Dispatcher (https://jira.mesosphere.com/browse/DCOS-41592)

Adds an integration test that 
- Submits a job with parameter `--conf spark.mesos.driver.labels=foo:bar`
- Examines `dcos task --json <driver task id>` output and asserts that the label is present

## How were these changes tested?

The new integration test was run locally targeting a dc/os cluster in AWS.

## Release Notes

n/a
