### PR TITLE
[DCOS-52116] fix for failing Spark apps dependent on external test data

### DIFF
--- a/scale-tests/streaming_test.py
+++ b/scale-tests/streaming_test.py
@@ -75,7 +75,7 @@ def main(dispatchers, jar_url, kafka_pkg_name, kafka_svc_name, num_consumers, de
         "--supervise",
         "--conf", "spark.mesos.containerizer=mesos",
         "--conf", "spark.mesos.driver.failoverTimeout=30",
-        "--conf", "spark.mesos.uris=http://norvig.com/big.txt",
+        "--conf", "spark.mesos.uris=https://infinity-soak.s3.amazonaws.com/data/norvig/big.txt",
         "--conf", "spark.port.maxRetries={}".format(port_retries),
         "--conf", "spark.scheduler.maxRegisteredResourcesWaitingTime=2400s",
         "--conf", "spark.scheduler.minRegisteredResourcesRatio=1.0"

--- a/tests/integration/test_kafka.py
+++ b/tests/integration/test_kafka.py
@@ -44,7 +44,7 @@ def test_pipeline(kerberos_flag, stop_count, jar_uri, keytab_secret, spark_servi
     broker_dns = sdk_cmd.svc_cli(KAFKA_PACKAGE_NAME, KAFKA_SERVICE_NAME, 'endpoints broker', json=True)['dns'][0]
     topic = "top1"
 
-    big_file, big_file_url = "file:///mnt/mesos/sandbox/big.txt", "http://norvig.com/big.txt"
+    big_file, big_file_url = "file:///mnt/mesos/sandbox/big.txt", "https://infinity-soak.s3.amazonaws.com/data/norvig/big.txt"
 
     # arguments to the application
     producer_args = " ".join([broker_dns, big_file, topic, kerberos_flag])

--- a/tests/jobs/scala/src/main/scala/KafkaJobs.scala
+++ b/tests/jobs/scala/src/main/scala/KafkaJobs.scala
@@ -30,7 +30,7 @@ import org.apache.spark.{SparkConf, SparkContext}
   * http://path-to-bucket/dcos-spark-scala-tests-assembly-0.1-SNAPSHOT.jar \
   * kafka-0-broker.secure-kafka.autoip.dcos.thisdcos.directory:1025 file:///mnt/mesos/sandbox/big.txt top1 false"
   *
-  * this assumes that {ARGS} contains `--conf spark.mesos.uris=http://norvig.com/big.txt`
+  * this assumes that {ARGS} contains `--conf spark.mesos.uris=https://infinity-soak.s3.amazonaws.com/data/norvig/big.txt`
   */
 object KafkaFeeder {
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-52116 Spark soak jobs fail due to dependency on norvig.com](https://jira.mesosphere.com/browse/DCOS-52116)

The external sample data file has been moved to a public S3 bucket with a test configuration change to use new location instead of norvig.com.

## How were these changes tested?

* Integration tests from this repository
* running affected soak jobs using the PR branch on 1.11s, 1.12s, and 1.13s clusters

## Release Notes

N/A
