### PR TITLE
[DCOS-41576] - Adds an integration test for spark dispatcher inactivity fix (SPARK-22574)

### DIFF
--- a/tests/resources/dispatcher_submit_request_missing_args.json
+++ b/tests/resources/dispatcher_submit_request_missing_args.json
@@ -1,0 +1,12 @@
+{
+  "action": "CreateSubmissionRequest",
+  "clientSparkVersion": "1.2.3",
+  "appResource": "noop-test.jar",
+  "mainClass": "noop.Test",
+  "environmentVariables": {
+    "PATH": "/dev/null"
+  },
+  "sparkProperties": {
+    "spark.app.name": "TestDispatcher"
+  }
+}

--- a/tests/resources/dispatcher_submit_request_valid.json
+++ b/tests/resources/dispatcher_submit_request_valid.json
@@ -1,0 +1,13 @@
+{
+  "action": "CreateSubmissionRequest",
+  "clientSparkVersion": "1.2.3",
+  "appResource": "noop-test.jar",
+  "mainClass": "noop.Test",
+  "appArgs": ["arg1", "arg2"],
+  "environmentVariables": {
+    "PATH": "/dev/null"
+  },
+  "sparkProperties": {
+    "spark.app.name": "TestDispatcher"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-41576](https://jira.mesosphere.com/browse/DCOS-41576)

Adds an integration test that sends a series of valid, invalid and valid again submission requests to spark dispatcher to verify it handles them as expected without going inactive (see SPARK-22574).

## How were these changes tested?

The new integration test was run locally targeting a dc/os cluster in AWS.

## Release Notes

n/a
