### PR TITLE
[DCOS-41589] Extracted foldered Spark tests into a separate module

### DIFF
--- a/tests/test_foldered_spark.py
+++ b/tests/test_foldered_spark.py
@@ -1,0 +1,84 @@
+import logging
+
+import pytest
+import retrying
+
+import sdk_cmd
+import sdk_hosts
+
+import spark_utils as utils
+
+log = logging.getLogger(__name__)
+
+service_name = utils.FOLDERED_SPARK_SERVICE_NAME
+
+
+@pytest.fixture(scope='module', autouse=True)
+def upload_test_jars(configure_security_spark, configure_universe):
+    utils.upload_dcos_test_jar()
+
+
+@pytest.fixture()
+def setup_spark(configure_security_spark, configure_universe):
+    try:
+        utils.require_spark()
+        zk = 'spark_mesos_dispatcher__path_to_spark'
+        utils.require_spark(service_name=service_name, zk=zk)
+        yield
+    finally:
+        utils.teardown_spark(service_name=service_name, zk=zk)
+
+
+@pytest.mark.dcos_min_version('1.10')
+@pytest.mark.sanity
+@pytest.mark.smoke
+def test_foldered_spark(setup_spark):
+    utils.run_tests(
+        app_url=utils.SPARK_EXAMPLES,
+        app_args="100",
+        expected_output="Pi is roughly 3",
+        service_name=service_name,
+        args=["--class org.apache.spark.examples.SparkPi"])
+
+
+@pytest.mark.sanity
+def test_dispatcher_task_stdout(setup_spark):
+    task_id = service_name.lstrip("/").replace("/", "_")
+    task = sdk_cmd._get_task_info(task_id)
+    if not task:
+        raise Exception("Failed to get '{}' task".format(task_id))
+
+    task_sandbox_path = sdk_cmd.get_task_sandbox_path(task_id)
+    if not task_sandbox_path:
+        raise Exception("Failed to get '{}' sandbox path".format(task_id))
+    agent_id = task["slave_id"]
+
+    task_sandbox = sdk_cmd.cluster_request(
+        "GET", "/slave/{}/files/browse?path={}".format(agent_id, task_sandbox_path)
+    ).json()
+    stdout_file = [f for f in task_sandbox if f["path"].endswith("/stdout")][0]
+    assert stdout_file["size"] > 0, "stdout file should have content"
+
+
+@pytest.mark.sanity
+def test_unique_vips():
+
+    @retrying.retry(wait_exponential_multiplier=1000, stop_max_attempt_number=7) # ~2 minutes
+    def verify_ip_is_reachable(ip):
+        ok, _ = sdk_cmd.master_ssh("curl -v {}".format(ip))
+        assert ok
+
+    spark1_service_name = "test/groupa/spark"
+    spark2_service_name = "test/groupb/spark"
+    try:
+        utils.require_spark(spark1_service_name)
+        utils.require_spark(spark2_service_name)
+
+        dispatcher1_ui_ip = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark1_service_name), 4040)
+        dispatcher2_ui_ip = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark2_service_name), 4040)
+
+        verify_ip_is_reachable(dispatcher1_ui_ip)
+        verify_ip_is_reachable(dispatcher2_ui_ip)
+    finally:
+        utils.teardown_spark(service_name=spark1_service_name)
+        utils.teardown_spark(service_name=spark2_service_name)

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -15,8 +15,6 @@ import retrying
 import shakedown
 
 import sdk_cmd
-import sdk_hosts
-import sdk_install
 import sdk_security
 import sdk_tasks
 import sdk_utils
@@ -317,19 +315,6 @@ def test_s3_env():
     assert len(list(s3.list("linecount-env.txt"))) > 0
 
 
-@pytest.mark.dcos_min_version('1.10')
-@pytest.mark.sanity
-@pytest.mark.smoke
-def test_foldered_spark():
-    service_name = utils.FOLDERED_SPARK_SERVICE_NAME
-    zk = 'spark_mesos_dispatcher__path_to_spark'
-    utils.require_spark(service_name=service_name, zk=zk)
-    test_sparkPi(service_name=service_name)
-    utils.teardown_spark(service_name=service_name, zk=zk)
-    # reinstall CLI so that it's available for the following tests:
-    sdk_cmd.run_cli('package install --cli {} --yes'.format(utils.SPARK_PACKAGE_NAME))
-
-
 @pytest.mark.sanity
 def test_cli_multiple_spaces():
     utils.run_tests(app_url=utils.SPARK_EXAMPLES,
@@ -384,53 +369,3 @@ def test_driver_executor_tls():
         sdk_cmd.run_cli('security secrets delete /{}'.format(keystore_secret))
         sdk_cmd.run_cli('security secrets delete /{}'.format(truststore_secret))
         sdk_cmd.run_cli('security secrets delete /{}'.format(my_secret))
-
-
-@pytest.mark.sanity
-def test_unique_vips():
-
-    @retrying.retry(wait_exponential_multiplier=1000, stop_max_attempt_number=7) # ~2 minutes
-    def verify_ip_is_reachable(ip):
-        ok, _ = sdk_cmd.master_ssh("curl -v {}".format(ip))
-        assert ok
-
-    spark1_service_name = "test/groupa/spark"
-    spark2_service_name = "test/groupb/spark"
-    try:
-        utils.require_spark(spark1_service_name)
-        utils.require_spark(spark2_service_name)
-
-        dispatcher1_ui_ip = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark1_service_name), 4040)
-        dispatcher2_ui_ip = sdk_hosts.vip_host("marathon", "dispatcher.{}".format(spark2_service_name), 4040)
-
-        verify_ip_is_reachable(dispatcher1_ui_ip)
-        verify_ip_is_reachable(dispatcher2_ui_ip)
-    finally:
-        sdk_install.uninstall(utils.SPARK_PACKAGE_NAME, spark1_service_name)
-        sdk_install.uninstall(utils.SPARK_PACKAGE_NAME, spark2_service_name)
-
-
-@pytest.mark.sanity
-def test_task_stdout():
-    service_name = utils.FOLDERED_SPARK_SERVICE_NAME
-
-    try:
-        task_id = service_name.lstrip("/").replace("/", "_")
-        utils.require_spark(service_name=service_name)
-
-        task = sdk_cmd._get_task_info(task_id)
-        if not task:
-            raise Exception("Failed to get '{}' task".format(task_id))
-
-        task_sandbox_path = sdk_cmd.get_task_sandbox_path(task_id)
-        if not task_sandbox_path:
-            raise Exception("Failed to get '{}' sandbox path".format(task_id))
-        agent_id = task["slave_id"]
-
-        task_sandbox = sdk_cmd.cluster_request(
-            "GET", "/slave/{}/files/browse?path={}".format(agent_id, task_sandbox_path)
-        ).json()
-        stdout_file = [f for f in task_sandbox if f["path"].endswith("/stdout")][0]
-        assert stdout_file["size"] > 0, "stdout file should have content"
-    finally:
-        sdk_install.uninstall(utils.SPARK_PACKAGE_NAME, service_name)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-53406: Fix race conditions in spark-build tests which uninstall DCOS spark CLI](https://jira.mesosphere.com/browse/DCOS-53406)

Tests for foldered Spark reinstall it with different names and then tear down. This led to environment modifications uninstalling Spark DCOS CLI and making the following tests fail. Also, uninstall procedures sometimes left stale ZK state which prevented subsequent jobs from execution. 

This change moves problematic tests to a separate module and provides fixtures and uninstall procedures which play along with the rest of the tests and don't cause conflicts.

## How were these changes tested?

* integration tests from this repository

## Release Notes

N/A
