### PR TITLE
[DCOS-53535] Spark StatsD Metrics Reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ logs/
 /spark/
 docker-dist
 docker-build
+statsd-reporter
 mesos-spark-integration-tests/
 mesos-spark-integration-tests-assembly-*.jar
 dcos-spark-scala-tests-assembly-*.jar

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -1,7 +1,7 @@
-
 # Enable StatsdSink for all instances by class name
-*.sink.statsd.class=org.apache.spark.metrics.sink.StatsdSink
+*.sink.statsd.class=org.apache.spark.metrics.sink.statsd.StatsdSink
 *.sink.statsd.prefix=spark
+*.sink.statsd.tags=app_type=spark
 *.sink.statsd.host=<STATSD_UDP_HOST>
 *.sink.statsd.port=<STATSD_UDP_PORT>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,6 +81,7 @@ RUN ln -s /bin/bash /usr/bin/bash \
 ENV SPARK_HOME="/opt/spark"
 ADD dist ${SPARK_HOME}
 ADD krb5.conf.mustache /etc/
+ADD spark-statsd-reporter.jar ${SPARK_HOME}/jars/mesosphere-statsd-reporter.jar
 
 # required to run as nobody
 RUN addgroup --gid 99 nobody \

--- a/spark-statsd-reporter/.gitignore
+++ b/spark-statsd-reporter/.gitignore
@@ -1,0 +1,3 @@
+.idea
+target
+*.iml

--- a/spark-statsd-reporter/README.md
+++ b/spark-statsd-reporter/README.md
@@ -1,0 +1,94 @@
+Spark StatsD Reporter
+---
+
+# Overview
+Spark StatsD Reporter provides a custom implementation of Spark sink which supports metric tagging, filtering, and 
+name formatting. Provided `MetricFormatter` normalizes metric names to a consistent form by removing variable parts and 
+placing them into tags.
+
+# Motivation
+Spark assigns metric **names** using `spark.app.id` and `spark.executor.id` as a part of them. Thus the number of metrics 
+is continuously growing because those IDs are unique between executions whereas the metrics themselves report the same thing. 
+It makes problematic the use of changing metric names in dashboards.
+
+For example, `jvm_heap_used` reported by all Spark instances (components):
+- `jvm_heap_used` (Dispatcher)
+- `<spark.app.id>_driver_jvm_heap_used` (driver)
+- `<spark.app.id>_<spark.executor.id>_jvm_heap_used` (executor)
+
+# Tag enrichment
+All the metrics reported by Driver or Executor instances are enriched with additional tags:
+
+- `<prefix>_app_name` for Spark application name
+- `<prefix>_instance` which is either `driver` or `executor`
+- `<prefix>_instance_id` which is Mesos Framework ID for Driver and Mesos Task ID for Executor
+- `<prefix>_namespace` contains the value of `spark.metrics.namespace` configuration property
+
+# Metric name formatting
+## Driver
+### Default naming
+Spark Driver metrics naming has the following format:
+```
+<spark.app.id>_driver_<source>_<metric>
+```
+
+If `spark.metrics.namespace` is provided, it replaces `spark.app.id`:
+```
+<spark.metrics.namespace>_driver_<source>_<metric>
+```
+
+`spark.app.id` is assigned to Mesos Framework ID and cannot be overwritten via configuration.
+
+Examples:
+```
+<prefix>_a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002_driver_jvm_heap_used
+
+# with --conf spark.metrics.namespace=namespace:
+<prefix>_namespace_driver_jvm_heap_used
+```
+
+### Formatted metrics
+Examples:
+```
+# without spark.metrics.namespace (namespace tag is set to 'default'):
+before: <prefix>_a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002_driver_jvm_heap_used
+after: <prefix>_driver_jvm_heap_used,<prefix>_namespace=default,<prefix>_app_name={value of spark.app.name},<prefix>_instance_type=driver,<prefix>_instance_id=a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002
+
+# with --conf spark.metrics.namespace=namespace (namespace tag is set to the value of spark.metrics.namespace):
+before: <prefix>_namespace_driver_jvm_heap_used
+after: <prefix>_driver_jvm_heap_used,<prefix>_namespace=namespace,<prefix>_app_name={value of spark.app.name},<prefix>_instance_type=driver,<prefix>_instance_id=a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002
+```
+
+## Executor
+### Default naming
+Spark Executor metrics naming has the following format:
+```
+<spark.app.id>_<spark.executor.id>_<source>_<metric>
+```
+
+If `spark.metrics.namespace` is provided, it replaces `spark.app.id`:
+```
+<spark.metrics.namespace>_<spark.executor.id>_<source>_<metric>
+```
+
+`spark.app.id` is assigned to Mesos Framework ID and cannot be overwritten via configuration.
+
+Examples:
+```
+<prefix>_a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002_aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0_jvm_heap_used
+
+# with --conf spark.metrics.namespace=namespace:
+<prefix>_namespace_aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0_jvm_heap_used
+```
+
+### Formatted metrics
+Examples:
+```
+# without spark.metrics.namespace (namespace tag is set to 'default'):
+before: <prefix>_a4d898f4_e1cf_4019_9950_c739bf9a3730_0003_driver_20190502210339_0002_aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0_jvm_heap_used
+after: <prefix>_executor_jvm_heap_used,<prefix>_namespace=default,<prefix>_app_name={value of spark.app.name},<prefix>_instance_type=executor,<prefix>_instance_id=aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0
+
+# with --conf spark.metrics.namespace=namespace (namespace tag is set to the value of spark.metrics.namespace):
+before: <prefix>_namespace_aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0_jvm_heap_used
+after: <prefix>_executor_jvm_heap_used,<prefix>_namespace=namespace,<prefix>_app_name={value of spark.app.name},<prefix>_instance_type=executor,<prefix>_instance_id=aa6ee344_1314_46ea_b346_dcf6a5cfeceb_0
+```

--- a/spark-statsd-reporter/pom.xml
+++ b/spark-statsd-reporter/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mesosphere</groupId>
+  <artifactId>spark-statsd-reporter</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>spark-statsd-reporter</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <dropwizard.metrics.version>3.1.5</dropwizard.metrics.version>
+    <spark.version>2.4.0</spark.version>
+    <spark.scala.version>2.11</spark.scala.version>
+  </properties>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${spark.scala.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/Configuration.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/Configuration.java
@@ -1,0 +1,25 @@
+package org.apache.spark.metrics.sink.statsd;
+
+final class Configuration {
+    final static class Keys {
+        final static String HOST = "host";
+        final static String PORT = "port";
+        final static String PREFIX = "prefix";
+        final static String TAGS = "tags";
+        final static String POLL_INTERVAL = "poll.interval";
+        final static String POLL_UNIT = "poll.unit";
+        final static String RATE_UNIT = "rate.unit";
+        final static String DURATION_UNIT = "duration.unit";
+    }
+
+    final static class Defaults {
+        final static String HOST = "127.0.0.1";
+        final static String PORT = "8125";
+        final static String TAGS = "";
+        final static String POLL_INTERVAL = "10";
+        final static String POLL_UNIT = "SECONDS";
+        final static String RATE_UNIT = "SECONDS";
+        final static String DURATION_UNIT = "MILLISECONDS";
+        final static String PREFIX = "";
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetails.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetails.java
@@ -1,0 +1,48 @@
+package org.apache.spark.metrics.sink.statsd;
+
+class InstanceDetails {
+    private final String applicationId;
+    private final String applicationName;
+    private final InstanceType instanceType;
+    private final String instanceId;
+    private final String namespace;
+
+    InstanceDetails(String applicationId, String applicationName, InstanceType instanceType, String instanceId, String namespace) {
+        this.applicationId = applicationId;
+        this.applicationName = applicationName;
+        this.instanceType = instanceType;
+        this.instanceId = instanceId;
+        this.namespace = namespace;
+    }
+
+    String getApplicationId() {
+        return applicationId;
+    }
+
+    String getApplicationName() {
+        return applicationName;
+    }
+
+    InstanceType getInstanceType() {
+        return instanceType;
+    }
+
+    String getInstanceId() {
+        return instanceId;
+    }
+
+    String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public String toString() {
+        return "InstanceDetails{" +
+                "applicationId='" + applicationId + '\'' +
+                ", applicationName='" + applicationName + '\'' +
+                ", instanceType=" + instanceType +
+                ", instanceId='" + instanceId + '\'' +
+                ", namespace='" + namespace + '\'' +
+                '}';
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
@@ -1,0 +1,40 @@
+package org.apache.spark.metrics.sink.statsd;
+
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Class used to access SparkEnv instance and extract relevant tags from SparkConf
+ * which is shared across Drivers and Executors. SparkEnv initializes Metric Sinks
+ * in its constructor is not available in the Sink during initialization (for Executors).
+ */
+@NotThreadSafe
+class InstanceDetailsProvider  {
+    private final static Logger logger = LoggerFactory.getLogger(StatsdReporter.class);
+
+    private InstanceDetails instance = null;
+
+    Optional<InstanceDetails> getInstanceDetails() {
+        if(instance == null) {
+            if (SparkEnv.get() == null) {
+                logger.warn("SparkEnv is not initialized, instance details unavailable");
+            } else {
+                SparkConf sparkConf = SparkEnv.get().conf();
+                instance =
+                        new InstanceDetails(
+                                sparkConf.getAppId(),
+                                sparkConf.get("spark.app.name"),
+                                InstanceType.valueOf(SparkEnv.get().metricsSystem().instance().toUpperCase()),
+                                sparkConf.get("spark.executor.id"),
+                                sparkConf.get("spark.metrics.namespace", "default")
+                        );
+            }
+        }
+        return Optional.ofNullable(instance);
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
@@ -1,0 +1,6 @@
+package org.apache.spark.metrics.sink.statsd;
+
+enum InstanceType {
+    DRIVER,
+    EXECUTOR
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
@@ -1,0 +1,92 @@
+package org.apache.spark.metrics.sink.statsd;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Joiner;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.util.Arrays.asList;
+
+class MetricFormatter {
+    private final static Pattern whitespacePattern = Pattern.compile("[\\s]+");
+    private final static String metricsFormat = "%s,%s:%s|%s";
+
+    private final String prefix;
+    private final InstanceDetailsProvider instanceDetailsProvider;
+    private final String[] tags;
+
+    MetricFormatter(InstanceDetailsProvider instanceDetailsProvider, String prefix, String[] tags) {
+        this.instanceDetailsProvider = instanceDetailsProvider;
+        this.prefix = prefix;
+        this.tags = tags;
+    }
+
+    String formatValue(Object value) {
+        if (value instanceof Float || value instanceof Double || value instanceof BigDecimal) {
+            return String.format("%2.2f", value);
+        } else if (value instanceof Number) {
+            return String.valueOf(value);
+        } else {
+            return "";
+        }
+    }
+
+    String buildMetricString(String name, String argument, Object value, String metricType) {
+        String fullName = MetricRegistry.name(name, argument);
+        return buildMetricString(fullName, value, metricType);
+    }
+
+    String buildMetricString(String name, Object value, String metricType) {
+        String tagString = buildTags();
+        String prefixedName = MetricRegistry.name(prefix, name);
+        String metricString =  String.format(metricsFormat, removeIds(prefixedName), tagString, formatValue(value), metricType);
+
+        return sanitize(metricString);
+    }
+
+    String removeIds(String name) {
+        //removing variable parts of a metric name (application and executor IDs)
+        return instanceDetailsProvider.getInstanceDetails().map(instanceDetails -> {
+            String formatted = name;
+
+            //remove spark.app.id if present
+            if (formatted.contains(instanceDetails.getApplicationId())) {
+                formatted = formatted.replaceAll(instanceDetails.getApplicationId() + "\\.", "");
+            }
+
+            //remove spark.executor.id if present
+            if (instanceDetails.getInstanceType() == InstanceType.EXECUTOR && formatted.contains(instanceDetails.getInstanceId())) {
+                formatted = formatted.replaceAll(instanceDetails.getInstanceId(), "executor");
+            }
+
+            return formatted.replaceAll(instanceDetails.getNamespace() + "\\.", "");
+        }).orElse(name);
+    }
+
+    String buildTags() {
+        //if instance details are available, enrich metric with tags
+        return instanceDetailsProvider.getInstanceDetails().map(instanceDetails -> {
+            List<String> extractedTags = new ArrayList<>(asList(
+                    prefix + "_app_name=" + instanceDetails.getApplicationName(),
+                    prefix + "_instance=" + instanceDetails.getInstanceType().toString(),
+                    prefix + "_instance_id=" + instanceDetails.getInstanceId()
+            ));
+
+            String namespace = instanceDetails.getNamespace();
+
+            if (namespace != null && !namespace.isEmpty()) {
+                extractedTags.add(prefix + "_namespace=" + namespace);
+            }
+
+            extractedTags.addAll(asList(tags));
+            return Joiner.on(",").join(extractedTags);
+        }).orElse(Joiner.on(",").join(tags));
+    }
+
+    String sanitize(String s) {
+        return whitespacePattern.matcher(s).replaceAll("_").toLowerCase();
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricType.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricType.java
@@ -1,0 +1,11 @@
+package org.apache.spark.metrics.sink.statsd;
+
+/**
+ * @see <a href="https://github.com/etsy/statsd/blob/master/docs/metric_types.md">
+ *        StatsD metric types</a>
+ */
+interface MetricType {
+    String COUNTER = "c";
+    String GAUGE = "g";
+    String TIMER = "ms";
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdReporter.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdReporter.java
@@ -1,0 +1,184 @@
+package org.apache.spark.metrics.sink.statsd;
+
+
+import com.codahale.metrics.*;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.spark.metrics.sink.statsd.MetricType.*;
+
+public class StatsdReporter extends ScheduledReporter {
+    private final static Logger logger = LoggerFactory.getLogger(StatsdReporter.class);
+    private final InetSocketAddress address;
+    private final MetricFormatter metricFormatter;
+
+    private StatsdReporter(MetricRegistry registry, MetricFormatter metricFormatter, String reporterName, TimeUnit rateUnit, TimeUnit durationUnit, MetricFilter filter, String host, int port) {
+        super(registry, reporterName, filter, rateUnit, durationUnit);
+        this.address = new InetSocketAddress(host, port);
+        this.metricFormatter = metricFormatter;
+    }
+
+    static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    public static class Builder {
+        private final MetricRegistry registry;
+        private MetricFormatter metricFormatter;
+        private String reporterName = "spark-statsd-reporter";
+        private TimeUnit rateUnit = TimeUnit.SECONDS;
+        private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
+        private MetricFilter filter = MetricFilter.ALL;
+        private String host = "127.0.0.1";
+        private int port = 8125;
+
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+        }
+
+        Builder formatter(MetricFormatter metricFormatter) {
+            this.metricFormatter = metricFormatter;
+            return this;
+        }
+
+        Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        StatsdReporter build() {
+            return new StatsdReporter(registry, metricFormatter, reporterName, rateUnit, durationUnit, filter, host, port);
+        }
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+        try (DatagramSocket socket = new DatagramSocket()) {
+            try {
+                reportGauges(gauges, socket);
+                reportCounters(counters, socket);
+                reportHistograms(histograms, socket);
+                reportMeters(meters, socket);
+                reportTimers(timers, socket);
+            } catch (StatsdReporterException e) {
+                logger.warn("Unable to send packets to StatsD", e);
+            }
+        } catch (IOException e) {
+            logger.warn("StatsD datagram socket construction failed", e);
+        }
+    }
+
+    @VisibleForTesting
+    void reportGauges(SortedMap<String, Gauge> gauges, DatagramSocket socket) {
+        gauges.forEach((name, value) ->
+                send(socket, metricFormatter.buildMetricString(name, value.getValue(), GAUGE))
+        );
+    }
+
+    @VisibleForTesting
+    void reportCounters(SortedMap<String, Counter> counters, DatagramSocket socket) {
+        counters.forEach((name, value) ->
+                send(socket, metricFormatter.buildMetricString(name, value.getCount(), COUNTER))
+        );
+    }
+
+    @VisibleForTesting
+    void reportHistograms(SortedMap<String, Histogram> histograms, DatagramSocket socket) {
+        histograms.forEach((name, histogram) -> {
+            Snapshot snapshot = histogram.getSnapshot();
+            send(socket,
+
+                    metricFormatter.buildMetricString(name, "count", histogram.getCount(), GAUGE),
+                    metricFormatter.buildMetricString(name, "max", snapshot.getMax(), TIMER),
+                    metricFormatter.buildMetricString(name, "mean", snapshot.getMean(), TIMER),
+                    metricFormatter.buildMetricString(name, "min", snapshot.getMin(), TIMER),
+                    metricFormatter.buildMetricString(name, "stddev", snapshot.getStdDev(), TIMER),
+                    metricFormatter.buildMetricString(name, "p50", snapshot.getMedian(), TIMER),
+                    metricFormatter.buildMetricString(name, "p75", snapshot.get75thPercentile(), TIMER),
+                    metricFormatter.buildMetricString(name, "p95", snapshot.get95thPercentile(), TIMER),
+                    metricFormatter.buildMetricString(name, "p98", snapshot.get98thPercentile(), TIMER),
+                    metricFormatter.buildMetricString(name, "p99", snapshot.get99thPercentile(), TIMER),
+                    metricFormatter.buildMetricString(name, "p999", snapshot.get999thPercentile(), TIMER)
+            );
+        });
+    }
+
+    @VisibleForTesting
+    void reportMeters(SortedMap<String, Meter> meters, DatagramSocket socket) {
+        meters.forEach((name, meter) -> {
+            send(socket,
+                    metricFormatter.buildMetricString(name, "count", meter.getCount(), GAUGE),
+                    metricFormatter.buildMetricString(name, "m1_rate", convertRate(meter.getOneMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "m5_rate", convertRate(meter.getFiveMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "m15_rate", convertRate(meter.getFifteenMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "mean_rate", convertRate(meter.getMeanRate()), TIMER)
+            );
+        });
+    }
+
+    @VisibleForTesting
+    void reportTimers(SortedMap<String, Timer> timers, DatagramSocket socket) {
+        timers.forEach((name, timer) -> {
+            Snapshot snapshot = timer.getSnapshot();
+            send(socket,
+                    metricFormatter.buildMetricString(name, "max", convertDuration(snapshot.getMax()), TIMER),
+                    metricFormatter.buildMetricString(name, "mean", convertDuration(snapshot.getMean()), TIMER),
+                    metricFormatter.buildMetricString(name, "min", convertDuration(snapshot.getMin()), TIMER),
+                    metricFormatter.buildMetricString(name, "stddev", convertDuration(snapshot.getStdDev()), TIMER),
+                    metricFormatter.buildMetricString(name, "p50", convertDuration(snapshot.getMedian()), TIMER),
+                    metricFormatter.buildMetricString(name, "p75", convertDuration(snapshot.get75thPercentile()), TIMER),
+                    metricFormatter.buildMetricString(name, "p95", convertDuration(snapshot.get95thPercentile()), TIMER),
+                    metricFormatter.buildMetricString(name, "p98", convertDuration(snapshot.get98thPercentile()), TIMER),
+                    metricFormatter.buildMetricString(name, "p99", convertDuration(snapshot.get99thPercentile()), TIMER),
+                    metricFormatter.buildMetricString(name, "p999", convertDuration(snapshot.get999thPercentile()), TIMER),
+                    metricFormatter.buildMetricString(name, "m1_rate", convertRate(timer.getOneMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "m5_rate", convertRate(timer.getFiveMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "m15_rate", convertRate(timer.getFifteenMinuteRate()), TIMER),
+                    metricFormatter.buildMetricString(name, "mean_rate", convertRate(timer.getMeanRate()), TIMER)
+            );
+        });
+    }
+
+    @VisibleForTesting
+    void send(DatagramSocket socket, String...metrics) {
+        for (String metric: metrics) {
+            byte[] bytes = metric.getBytes(UTF_8);
+            DatagramPacket packet = new DatagramPacket(bytes, bytes.length, address);
+            try {
+                socket.send(packet);
+            } catch (IOException e) {
+                throw new StatsdReporterException(e);
+            }
+        }
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdReporterException.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdReporterException.java
@@ -1,0 +1,11 @@
+package org.apache.spark.metrics.sink.statsd;
+
+class StatsdReporterException extends RuntimeException {
+    StatsdReporterException(String message) {
+        super(message);
+    }
+
+    StatsdReporterException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
@@ -1,0 +1,67 @@
+package org.apache.spark.metrics.sink.statsd;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.spark.metrics.sink.Sink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.spark.metrics.sink.statsd.Configuration.Defaults;
+import static org.apache.spark.metrics.sink.statsd.Configuration.Keys;
+
+public class StatsdSink implements Sink {
+    private final static Logger logger = LoggerFactory.getLogger(StatsdSink.class);
+    private final StatsdReporter reporter;
+
+    private int pollInterval;
+    private TimeUnit pollUnit;
+    private final String prefix;
+
+    public StatsdSink(Properties properties, MetricRegistry registry, org.apache.spark.SecurityManager securityMgr) {
+        logger.info("Starting StatsdSink with properties:\n" + properties.toString());
+        this.prefix = properties.getProperty(Keys.PREFIX, Defaults.PREFIX);
+        this.pollInterval = Integer.parseInt(properties.getProperty(Keys.POLL_INTERVAL, Defaults.POLL_INTERVAL));
+        this.pollUnit = TimeUnit.valueOf(properties.getProperty(Keys.POLL_UNIT, Defaults.POLL_UNIT).toUpperCase());
+
+        String host = properties.getProperty(Keys.HOST, Defaults.HOST);
+        int port = Integer.parseInt(properties.getProperty(Keys.PORT, Defaults.PORT));
+
+        TimeUnit rateUnit = TimeUnit.valueOf(properties.getProperty(Keys.RATE_UNIT, Defaults.RATE_UNIT).toUpperCase());
+        TimeUnit durationUnit = TimeUnit.valueOf(properties.getProperty(Keys.DURATION_UNIT, Defaults.DURATION_UNIT).toUpperCase());
+
+        //TODO: add filtering support
+
+        String[] tags = properties.getProperty(Keys.TAGS, Defaults.TAGS).split(",");
+
+        this.reporter = StatsdReporter
+                .forRegistry(registry)
+                .formatter(new MetricFormatter(new InstanceDetailsProvider(), prefix, tags))
+                .host(host)
+                .port(port)
+                .convertRatesTo(rateUnit)
+                .convertDurationsTo(durationUnit)
+                .build();
+    }
+
+    @Override
+    public void start() {
+        reporter.start(pollInterval, pollUnit);
+        logger.info("StatsdSink started with prefix: " + prefix);
+    }
+
+    @Override
+    public void stop() {
+        reporter.stop();
+        logger.info("StatsdSink stopped");
+    }
+
+    /**
+     * This method is called by SparkContext, Executors, and Spark Standalone instances prior to shutting down
+     */
+    @Override
+    public void report(){
+        reporter.report();
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-53535](https://jira.mesosphere.com/browse/DCOS-53535)

Dedicated StatsD metric reporter with tagging and metric name standardization support.

Original problem:
Spark assigns metric **names** using `spark.app.id` and `spark.executor.id` as a part of them. Thus the number of metrics is continuously growing because those IDs are unique between executions whereas the metrics themselves report the same thing. Another issue which arises here is how to use constantly changing metric names in dashboards.

For example, `jvm_heap_used` reported by all Spark instances (components):
- `jvm_heap_used` (Dispatcher)
- `<spark.app.id>_driver_jvm_heap_used` (driver)
- `<spark.app.id>_<spark.executor.id>_jvm_heap_used` (executor)

This PR provides PoC implementation of StatsD reporter which removes variable parts of metric names and moves them to tags to ease the pressure on underlying time series database and provide metric names consistent across executions.

Example:
- before: `<spark.app.id>_driver_jvm_heap_used` (driver)
   after: `driver_jvm_heap_used,instance_type=driver,instance_id=<spark.app.id>`
- before: `<spark.app.id>_<spark.executor.id>_jvm_heap_used` (executor)
   after: `executor_jvm_heap_used,instance_type=executor,instance_id=<spark.executor.id>`

## How were these changes tested?

By manually running Spark jobs submitted via Dispatcher/Metronome/Marathon/`spark-submit` and a sample Grafana Dashboard:

![image](https://user-images.githubusercontent.com/1193506/57666222-1ea1e400-75b4-11e9-8675-be512e8f6661.png)

![image](https://user-images.githubusercontent.com/1193506/57666236-29f50f80-75b4-11e9-940c-7d1d246879dc.png)

## Release Notes

* consistent metrics naming and tagging support for DCOS monitoring
