### PR TITLE
 [DCOS-53561] Add support for accurate Scheduler Plan status in the UI with SDK 0.56.0+

### DIFF
--- a/universe/config.json
+++ b/universe/config.json
@@ -103,6 +103,30 @@
                     "type": "string",
                     "description": "Specify the integer UID for the Linux user, overriding service.user, when running the Spark Driver and Executor containers with the Docker Engine. Directly translates to docker run '--user' parameter. Note: This should typically be set to 99 when running as nobody (default) on RHEL/CentOS.",
                     "default": ""
+                },
+                "check": {
+                    "description": "Health check used to determine the scheduler health based on the status of the scheduler plans.",
+                    "type": "object",
+                    "properties": {
+                        "intervalSeconds": {
+                            "type": "integer",
+                            "description": "The period in seconds to wait after the last check has completed to start the next check.",
+                            "default": 30,
+                            "minimum": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer",
+                            "description": " An amount of time in seconds to wait for check to succeed.",
+                            "default": 20,
+                            "minimum": 20
+                        },
+                        "delaySeconds": {
+                            "type": "integer",
+                            "description": "An amount of time in seconds to wait before starting the check attempts.",
+                            "default": 15,
+                            "minimum": 15
+                        }
+                    }
                 }
             }
         },

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -218,5 +218,14 @@
         "{{hdfs.config-url}}/hdfs-site.xml",
         "{{hdfs.config-url}}/core-site.xml"
     {{/hdfs.config-url}}
-    ]
+    ],
+    "check": {
+        "http": {
+            "portIndex": 0,
+            "path": "/v1/health"
+        },
+        "intervalSeconds": {{service.check.intervalSeconds}},
+        "timeoutSeconds": {{service.check.timeoutSeconds}},
+        "delaySeconds": {{service.check.delaySeconds}}
+    }
 }


### PR DESCRIPTION
## What changes are proposed in this PR?

Resolves [DCOS-53561](https://jira.mesosphere.com/browse/DCOS-53561)
Added code for a check to show accurate scheduler plan status in UI with SDK 0.56.0 or later. Also, The default values are parameterized so that they can be configured at the time of deployment.

## How were these changes tested?
TC CI tests