### PR TITLE
[DCOS-54556] Static config update for statsd reporter

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -1,7 +1,6 @@
 # Enable StatsdSink for all instances by class name
 *.sink.statsd.class=org.apache.spark.metrics.sink.statsd.StatsdSink
-*.sink.statsd.prefix=spark
-*.sink.statsd.tags=app_type=spark
+*.sink.statsd.prefix=
 *.sink.statsd.host=<STATSD_UDP_HOST>
 *.sink.statsd.port=<STATSD_UDP_PORT>
 

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -1,6 +1,7 @@
 # Enable StatsdSink for all instances by class name
 *.sink.statsd.class=org.apache.spark.metrics.sink.statsd.StatsdSink
 *.sink.statsd.prefix=
+*.sink.statsd.tags=
 *.sink.statsd.host=<STATSD_UDP_HOST>
 *.sink.statsd.port=<STATSD_UDP_PORT>
 

--- a/spark-statsd-reporter/pom.xml
+++ b/spark-statsd-reporter/pom.xml
@@ -46,5 +46,11 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetails.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetails.java
@@ -3,13 +3,15 @@ package org.apache.spark.metrics.sink.statsd;
 class InstanceDetails {
     private final String applicationId;
     private final String applicationName;
+    private final String applicationOrigin;
     private final InstanceType instanceType;
     private final String instanceId;
     private final String namespace;
 
-    InstanceDetails(String applicationId, String applicationName, InstanceType instanceType, String instanceId, String namespace) {
+    InstanceDetails(String applicationId, String applicationName, String applicationOrigin, InstanceType instanceType, String instanceId, String namespace) {
         this.applicationId = applicationId;
         this.applicationName = applicationName;
+        this.applicationOrigin = applicationOrigin;
         this.instanceType = instanceType;
         this.instanceId = instanceId;
         this.namespace = namespace;
@@ -21,6 +23,10 @@ class InstanceDetails {
 
     String getApplicationName() {
         return applicationName;
+    }
+
+    public String getApplicationOrigin() {
+        return applicationOrigin;
     }
 
     InstanceType getInstanceType() {
@@ -40,6 +46,7 @@ class InstanceDetails {
         return "InstanceDetails{" +
                 "applicationId='" + applicationId + '\'' +
                 ", applicationName='" + applicationName + '\'' +
+                ", applicationOrigin='" + applicationOrigin + '\'' +
                 ", instanceType=" + instanceType +
                 ", instanceId='" + instanceId + '\'' +
                 ", namespace='" + namespace + '\'' +

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
@@ -35,11 +35,12 @@ class InstanceDetailsProvider  {
 
     InstanceDetails buildInstanceDetails() {
         SparkConf sparkConf = SparkEnv.get().conf();
+        String instanceType = System.getenv("INSTANCE_TYPE");
         return new InstanceDetails(
                 sparkConf.getAppId(),
                 sparkConf.get("spark.app.name"),
                 System.getenv("SPARK_APP_ORIGIN"),
-                InstanceType.valueOf(SparkEnv.get().metricsSystem().instance().toUpperCase()),
+                instanceType != null ? InstanceType.valueOf(instanceType.toUpperCase()) : null,
                 sparkConf.get("spark.executor.id"),
                 sparkConf.get("spark.metrics.namespace", "default")
         );

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
@@ -35,11 +35,13 @@ class InstanceDetailsProvider  {
 
     InstanceDetails buildInstanceDetails() {
         SparkConf sparkConf = SparkEnv.get().conf();
+        String instanceType = System.getenv("SPARK_INSTANCE_TYPE") != null
+                ? System.getenv("SPARK_INSTANCE_TYPE") : "UNDEFINED";
         return new InstanceDetails(
                 sparkConf.getAppId(),
                 sparkConf.get("spark.app.name"),
-                System.getenv("SPARK_APP_ORIGIN"),
-                InstanceType.valueOf(SparkEnv.get().metricsSystem().instance().toUpperCase()),
+                System.getenv("SPARK_APPLICATION_ORIGIN"),
+                InstanceType.valueOf(instanceType.toUpperCase()),
                 sparkConf.get("spark.executor.id"),
                 sparkConf.get("spark.metrics.namespace", "default")
         );

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
@@ -35,12 +35,11 @@ class InstanceDetailsProvider  {
 
     InstanceDetails buildInstanceDetails() {
         SparkConf sparkConf = SparkEnv.get().conf();
-        String instanceType = System.getenv("INSTANCE_TYPE");
         return new InstanceDetails(
                 sparkConf.getAppId(),
                 sparkConf.get("spark.app.name"),
                 System.getenv("SPARK_APP_ORIGIN"),
-                instanceType != null ? InstanceType.valueOf(instanceType.toUpperCase()) : null,
+                InstanceType.valueOf(SparkEnv.get().metricsSystem().instance().toUpperCase()),
                 sparkConf.get("spark.executor.id"),
                 sparkConf.get("spark.metrics.namespace", "default")
         );

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProvider.java
@@ -38,6 +38,7 @@ class InstanceDetailsProvider  {
         return new InstanceDetails(
                 sparkConf.getAppId(),
                 sparkConf.get("spark.app.name"),
+                System.getenv("SPARK_APP_ORIGIN"),
                 InstanceType.valueOf(SparkEnv.get().metricsSystem().instance().toUpperCase()),
                 sparkConf.get("spark.executor.id"),
                 sparkConf.get("spark.metrics.namespace", "default")

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
@@ -1,6 +1,8 @@
 package org.apache.spark.metrics.sink.statsd;
 
 enum InstanceType {
+    UNDEFINED,
+    DISPATCHER,
     DRIVER,
     EXECUTOR
 }

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
@@ -1,6 +1,7 @@
 package org.apache.spark.metrics.sink.statsd;
 
 enum InstanceType {
+    DISPATCHER,
     DRIVER,
     EXECUTOR
 }

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/InstanceType.java
@@ -1,7 +1,6 @@
 package org.apache.spark.metrics.sink.statsd;
 
 enum InstanceType {
-    DISPATCHER,
     DRIVER,
     EXECUTOR
 }

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
@@ -70,8 +70,8 @@ class MetricFormatter {
         //if instance details are available, enrich metric with tags
         return instanceDetailsProvider.getInstanceDetails().map(instanceDetails -> {
             List<String> extractedTags = new ArrayList<>(asList(
+                    prefix + "_origin=" + instanceDetails.getApplicationOrigin(),
                     prefix + "_app_name=" + instanceDetails.getApplicationName(),
-                    prefix + "_instance=" + instanceDetails.getInstanceType().toString(),
                     prefix + "_instance_id=" + instanceDetails.getInstanceId()
             ));
 

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/MetricFormatter.java
@@ -70,10 +70,13 @@ class MetricFormatter {
         //if instance details are available, enrich metric with tags
         return instanceDetailsProvider.getInstanceDetails().map(instanceDetails -> {
             List<String> extractedTags = new ArrayList<>(asList(
-                    prefix + "_origin=" + instanceDetails.getApplicationOrigin(),
                     prefix + "_app_name=" + instanceDetails.getApplicationName(),
                     prefix + "_instance_id=" + instanceDetails.getInstanceId()
             ));
+
+            if (instanceDetails.getApplicationOrigin() != null) {
+                extractedTags.add(prefix + "_origin=" + instanceDetails.getApplicationOrigin());
+            }
 
             String namespace = instanceDetails.getNamespace();
 

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
@@ -22,7 +22,7 @@ public class StatsdSink implements Sink {
 
     public StatsdSink(Properties properties, MetricRegistry registry, org.apache.spark.SecurityManager securityMgr) {
         logger.info("Starting StatsdSink with properties:\n" + properties.toString());
-        this.prefix = MetricRegistry.name(MANDATORY_PREFIX, properties.getProperty(Keys.PREFIX, Defaults.PREFIX));
+        this.prefix = MetricRegistry.name(properties.getProperty(Keys.PREFIX, Defaults.PREFIX),MANDATORY_PREFIX);
         this.pollInterval = Integer.parseInt(properties.getProperty(Keys.POLL_INTERVAL, Defaults.POLL_INTERVAL));
         this.pollUnit = TimeUnit.valueOf(properties.getProperty(Keys.POLL_UNIT, Defaults.POLL_UNIT).toUpperCase());
 

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
@@ -13,7 +13,8 @@ import static org.apache.spark.metrics.sink.statsd.Configuration.Keys;
 
 public class StatsdSink implements Sink {
     private final static Logger logger = LoggerFactory.getLogger(StatsdSink.class);
-    private static final String MANDATORY_PREFIX = "spark";
+    // Static prefix is used to distinguish Spark JVM source from other JVM applications in the cluster
+    private static final String STATIC_PREFIX = "spark";
     private final StatsdReporter reporter;
 
     private int pollInterval;
@@ -22,7 +23,7 @@ public class StatsdSink implements Sink {
 
     public StatsdSink(Properties properties, MetricRegistry registry, org.apache.spark.SecurityManager securityMgr) {
         logger.info("Starting StatsdSink with properties:\n" + properties.toString());
-        this.prefix = MetricRegistry.name(properties.getProperty(Keys.PREFIX, Defaults.PREFIX),MANDATORY_PREFIX);
+        this.prefix = MetricRegistry.name(properties.getProperty(Keys.PREFIX, Defaults.PREFIX), STATIC_PREFIX);
         this.pollInterval = Integer.parseInt(properties.getProperty(Keys.POLL_INTERVAL, Defaults.POLL_INTERVAL));
         this.pollUnit = TimeUnit.valueOf(properties.getProperty(Keys.POLL_UNIT, Defaults.POLL_UNIT).toUpperCase());
 

--- a/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
+++ b/spark-statsd-reporter/src/main/java/org/apache/spark/metrics/sink/statsd/StatsdSink.java
@@ -13,6 +13,7 @@ import static org.apache.spark.metrics.sink.statsd.Configuration.Keys;
 
 public class StatsdSink implements Sink {
     private final static Logger logger = LoggerFactory.getLogger(StatsdSink.class);
+    private static final String MANDATORY_PREFIX = "spark";
     private final StatsdReporter reporter;
 
     private int pollInterval;
@@ -21,7 +22,7 @@ public class StatsdSink implements Sink {
 
     public StatsdSink(Properties properties, MetricRegistry registry, org.apache.spark.SecurityManager securityMgr) {
         logger.info("Starting StatsdSink with properties:\n" + properties.toString());
-        this.prefix = properties.getProperty(Keys.PREFIX, Defaults.PREFIX);
+        this.prefix = MetricRegistry.name(MANDATORY_PREFIX, properties.getProperty(Keys.PREFIX, Defaults.PREFIX));
         this.pollInterval = Integer.parseInt(properties.getProperty(Keys.POLL_INTERVAL, Defaults.POLL_INTERVAL));
         this.pollUnit = TimeUnit.valueOf(properties.getProperty(Keys.POLL_UNIT, Defaults.POLL_UNIT).toUpperCase());
 

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProviderTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProviderTest.java
@@ -2,7 +2,6 @@ package org.apache.spark.metrics.sink.statsd;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
-import org.apache.spark.metrics.MetricsSystem;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -24,7 +23,6 @@ import static org.mockito.Mockito.*;
 public class InstanceDetailsProviderTest {
 
     @Mock SparkEnv env;
-    @Mock MetricsSystem metricsSystem;
     @Rule private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private static final String appName = "test-app";
@@ -49,7 +47,7 @@ public class InstanceDetailsProviderTest {
 
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
-        environmentVariables.set("INSTANCE_TYPE", instanceType);
+        environmentVariables.set("SPARK_INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = spy(InstanceDetailsProvider.class);
         provider.getInstanceDetails();
@@ -66,7 +64,7 @@ public class InstanceDetailsProviderTest {
 
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
-        environmentVariables.set("INSTANCE_TYPE", instanceType);
+        environmentVariables.set("SPARK_INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -93,7 +91,7 @@ public class InstanceDetailsProviderTest {
 
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
-        environmentVariables.set("INSTANCE_TYPE", instanceType);
+        environmentVariables.set("SPARK_INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -119,7 +117,7 @@ public class InstanceDetailsProviderTest {
 
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
-        environmentVariables.set("INSTANCE_TYPE", instanceType);
+        environmentVariables.set("SPARK_INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -143,7 +141,7 @@ public class InstanceDetailsProviderTest {
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
 
-        environmentVariables.set("SPARK_APP_ORIGIN", origin);
+        environmentVariables.set("SPARK_APPLICATION_ORIGIN", origin);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProviderTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/InstanceDetailsProviderTest.java
@@ -45,11 +45,11 @@ public class InstanceDetailsProviderTest {
     public void testInitialization() {
         PowerMockito.mockStatic(SparkEnv.class);
         SparkConf conf = getDefaultSparkConf();
+        final String instanceType = "driver";
 
-        when(metricsSystem.instance()).thenReturn("driver");
-        when(env.metricsSystem()).thenReturn(metricsSystem);
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
+        environmentVariables.set("INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = spy(InstanceDetailsProvider.class);
         provider.getInstanceDetails();
@@ -62,11 +62,11 @@ public class InstanceDetailsProviderTest {
     public void testExecutorInstanceDetails() {
         PowerMockito.mockStatic(SparkEnv.class);
         SparkConf conf = getDefaultSparkConf();
+        final String instanceType = "executor";
 
-        when(metricsSystem.instance()).thenReturn("executor");
-        when(env.metricsSystem()).thenReturn(metricsSystem);
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
+        environmentVariables.set("INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -89,12 +89,11 @@ public class InstanceDetailsProviderTest {
         SparkConf conf = getDefaultSparkConf();
         conf.set("spark.app.id", applicationId);
         conf.set("spark.executor.id", applicationId);
+        final String instanceType = "driver";
 
-
-        when(metricsSystem.instance()).thenReturn("driver");
-        when(env.metricsSystem()).thenReturn(metricsSystem);
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
+        environmentVariables.set("INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -116,11 +115,11 @@ public class InstanceDetailsProviderTest {
         String namespace = "test_namespace";
         SparkConf conf = getDefaultSparkConf();
         conf.set("spark.metrics.namespace", namespace);
+        final String instanceType = "driver";
 
-        when(metricsSystem.instance()).thenReturn("driver");
-        when(env.metricsSystem()).thenReturn(metricsSystem);
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
+        environmentVariables.set("INSTANCE_TYPE", instanceType);
 
         InstanceDetailsProvider provider = new InstanceDetailsProvider();
         Optional<InstanceDetails> instanceDetails = provider.getInstanceDetails();
@@ -141,8 +140,6 @@ public class InstanceDetailsProviderTest {
         SparkConf conf = getDefaultSparkConf();
         final String origin = "spark-test";
 
-        when(metricsSystem.instance()).thenReturn("driver");
-        when(env.metricsSystem()).thenReturn(metricsSystem);
         when(env.conf()).thenReturn(conf);
         when(SparkEnv.get()).thenReturn(env);
 

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/MetricFormatterTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/MetricFormatterTest.java
@@ -22,7 +22,7 @@ public class MetricFormatterTest {
     public void simpleDriverMetricString() {
         when(provider.getInstanceDetails()).thenReturn(Optional.of(new InstanceDetails(
                 "834d77b5-a7b1-4c9d-9742-0f95d39d15e0-0002-driver-20190430095449-0001", "Test Spark App",
-                InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
+                "spark-test", InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
         String[] tags = { };
         MetricFormatter formatter = new MetricFormatter(provider, "spark", tags);
 
@@ -30,7 +30,7 @@ public class MetricFormatterTest {
 
         assertTrue(actual.startsWith("spark.driver.testsource.test_metric,"));
         assertTrue(actual.contains(",spark_app_name=test_spark_app"));
-        assertTrue(actual.contains(",spark_instance=driver"));
+        assertTrue(actual.contains(",spark_origin=spark-test"));
         assertTrue(actual.contains(",spark_instance_id=aa31a823-2c7c-40e0-aef9-4b2a42adb461"));
         assertTrue(actual.contains(",spark_namespace=default"));
         assertTrue(actual.endsWith(":1|g"));
@@ -40,7 +40,7 @@ public class MetricFormatterTest {
     public void simpleExecutorMetricString() {
         when(provider.getInstanceDetails()).thenReturn(Optional.of(new InstanceDetails(
                 "834d77b5-a7b1-4c9d-9742-0f95d39d15e0-0002-driver-20190430095449-0001", "Test Spark App",
-                InstanceType.EXECUTOR, "aa31a823-2c7c-40e0-aef9-4b2a42adb461_0", "default")));
+                "spark-test", InstanceType.EXECUTOR, "aa31a823-2c7c-40e0-aef9-4b2a42adb461_0", "default")));
         String[] tags = { };
         MetricFormatter formatter = new MetricFormatter(provider, "spark", tags);
 
@@ -48,7 +48,7 @@ public class MetricFormatterTest {
 
         assertTrue(actual.startsWith("spark.executor.testsource.test_metric,"));
         assertTrue(actual.contains(",spark_app_name=test_spark_app"));
-        assertTrue(actual.contains(",spark_instance=executor"));
+        assertTrue(actual.contains(",spark_origin=spark-test"));
         assertTrue(actual.contains(",spark_instance_id=aa31a823-2c7c-40e0-aef9-4b2a42adb461_0"));
         assertTrue(actual.contains(",spark_namespace=default"));
         assertTrue(actual.endsWith(":1|g"));
@@ -58,7 +58,7 @@ public class MetricFormatterTest {
     public void predefinedTags() {
         when(provider.getInstanceDetails()).thenReturn(Optional.of(new InstanceDetails(
                 "834d77b5-a7b1-4c9d-9742-0f95d39d15e0-0002-driver-20190430095449-0001", "Test Spark App",
-                InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
+                "spark-test", InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
         String[] tags = { "foo=bar" };
         MetricFormatter formatter = new MetricFormatter(provider, "spark", tags);
 
@@ -71,7 +71,7 @@ public class MetricFormatterTest {
     public void precisionFormat() {
         when(provider.getInstanceDetails()).thenReturn(Optional.of(new InstanceDetails(
                 "834d77b5-a7b1-4c9d-9742-0f95d39d15e0-0002-driver-20190430095449-0001", "Test Spark App",
-                InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
+                "spark-test", InstanceType.DRIVER, "aa31a823-2c7c-40e0-aef9-4b2a42adb461", "default")));
         String[] tags = { };
         MetricFormatter formatter = new MetricFormatter(provider, "spark", tags);
 

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdReporterTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdReporterTest.java
@@ -27,7 +27,7 @@ public class StatsdReporterTest {
         InstanceDetailsProvider provider = Mockito.mock(InstanceDetailsProvider.class);
 
         when(provider.getInstanceDetails()).thenReturn(Optional.of(new InstanceDetails(
-                "test-app-01", "Test Spark App",
+                "test-app-01", "Test Spark App", "spark-test",
                 InstanceType.DRIVER, "test-instance-01", "default")));
         String[] tags = {};
         this.formatter = new MetricFormatter(provider, "spark", tags);

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdSinkTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdSinkTest.java
@@ -50,7 +50,7 @@ public class StatsdSinkTest {
             sleep(100);
 
             // Provided port, prefix and tags check
-            assertEquals("spark.myprefix.test_gauge,foo=bar:1|g", server.receivedMessages().get(0));
+            assertEquals("myprefix.spark.test_gauge,foo=bar:1|g", server.receivedMessages().get(0));
         }
     }
 }

--- a/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdSinkTest.java
+++ b/spark-statsd-reporter/src/test/java/org/apache/spark/metrics/sink/statsd/StatsdSinkTest.java
@@ -26,7 +26,7 @@ public class StatsdSinkTest {
             sleep(100);
 
             // Default host, port and prefix check
-            assertEquals("test_gauge,:1|g", server.receivedMessages().get(0));
+            assertEquals("spark.test_gauge,:1|g", server.receivedMessages().get(0));
         }
     }
 
@@ -38,7 +38,7 @@ public class StatsdSinkTest {
 
             Properties props = new Properties();
             props.put(Configuration.Keys.PORT, Integer.toString(testUdpPort));
-            props.put(Configuration.Keys.PREFIX, "spark");
+            props.put(Configuration.Keys.PREFIX, "myprefix");
             props.put(Configuration.Keys.TAGS, "foo=bar");
 
             StatsdSink sink = new StatsdSink(props, registry, null);
@@ -50,7 +50,7 @@ public class StatsdSinkTest {
             sleep(100);
 
             // Provided port, prefix and tags check
-            assertEquals("spark.test_gauge,foo=bar:1|g", server.receivedMessages().get(0));
+            assertEquals("spark.myprefix.test_gauge,foo=bar:1|g", server.receivedMessages().get(0));
         }
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-54556](https://jira.mesosphere.com/browse/DCOS-54556)

- Removes _app_type_ and _instance_type_ tags from metrics.
- Adds mandatory _spark_ prefix to metrics, that can't be overridden
- Adds _spark_origin_ tag with value of SPARK_APP_ORIGIN environment variable

## How were these changes tested?

Manually and with unit tests

## Release Notes

n/a
