### PR TITLE
[DCOS-54117] Add service name validation for Spark and Spark-History

### DIFF
--- a/history/universe/config.json
+++ b/history/universe/config.json
@@ -8,7 +8,8 @@
                 "name": {
                     "default": "spark-history",
                     "description": "The app name for the Spark History Server.  The service will be available at {{https-protocol}}<dcos_url>/service/<name>/",
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$"
                 },
                 "cpus": {
                     "default": 1,

--- a/universe/config.json
+++ b/universe/config.json
@@ -8,7 +8,8 @@
                 "name": {
                     "default": "spark",
                     "description": "The Spark Dispatcher will register with Mesos with this as a framework name.  This service will be available at {{https-protocol}}<dcos-url>/service/<name>/",
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$"
                 },
                 "cpus": {
                     "default": 1,


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds UI validation for service names for Spark and Spark History packages.

Resolves [DCOS-54117](https://jira.mesosphere.com/browse/DCOS-54117)
Regexp pattern added for service name validation.

## How were these changes tested?
Tested on a cluster with custom stubs for each package.
Results:
![2019-06-06_17-36](https://user-images.githubusercontent.com/47157503/59042702-9d243580-8883-11e9-8bf3-e0c1d0b12439.png)
![2019-06-06_17-41](https://user-images.githubusercontent.com/47157503/59042718-a0b7bc80-8883-11e9-9efe-899fbc847559.png)
