### PR TITLE
DCOS-54708: UCR containerizer by default

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -54,13 +54,13 @@ dcos package install spark --cli
 # Custom Installation
 
 You can customize the default configuration properties by creating a JSON options file and passing it to `dcos package
-install --options`. For example, to launch the Dispatcher using the Universal Container Runtime (UCR), create a file
-called `options.json`:
+install --options`. For example, to launch the Dispatcher using Docker instead of the Universal Container Runtime (UCR),
+create a file called `options.json`:
 
 ```json
 {
   "service": {
-    "UCR_containerizer": true
+    "UCR_containerizer": false
   }
 }
 ```

--- a/universe/config.json
+++ b/universe/config.json
@@ -97,7 +97,7 @@
                 "UCR_containerizer": {
                     "type": "boolean",
                     "description": "Launch the Dispatcher using the Universal Container Runtime (UCR)",
-                    "default": false
+                    "default": true
                 },
                 "docker_user": {
                     "type": "string",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-54708](https://jira.mesosphere.com/browse/DCOS-54708)

* Changed default value for `UCR_containerizer` parameter to `true`

## How were these changes tested?

* By running existing integration tests

## Release Notes

* Enabled UCR containerizer by default for Spark Dispatcher

