### PR TITLE
Spark 2.4.3 RC1 permanent stub release

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
-    "spark_version": "2.4.0",
+    "spark_version": "2.4.3",
     "default_spark_dist": {
         "hadoop_version": "2.9",
-        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.9.2-openjdk8-SNAPSHOT-20190530.tgz"
+        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.3-bin-hadoop2.9.2-openjdk8-rc1.tgz"
     },
     "spark_dist": [
         {
             "hadoop_version": "2.9",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.9.2-openjdk8-SNAPSHOT-20190530.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.3-bin-hadoop2.9.2-openjdk8-rc1.tgz"
         },
         {
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.7.7-openjdk8-SNAPSHOT-20190530.tgz"
+            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.3-bin-hadoop2.7.7-openjdk8-rc1.tgz"
         }
     ]
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-57588: Publish a base tech update permanent stub fo early access](https://jira.mesosphere.com/browse/DCOS-57588)

Changes:
- upgraded Spark base tech from 2.4.0 to 2.4.3

## How were these changes tested?

- integration tests from this repo

## Release Notes

N/A