### PR TITLE
[DCOS-54709] Scala 2.12 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ manifest-dist:
 	popd
 
 HADOOP_VERSION ?= $(shell jq ".default_spark_dist.hadoop_version" "$(ROOT_DIR)/manifest.json")
+SCALA_VERSION ?= $(shell jq ".default_spark_dist.scala_version" "$(ROOT_DIR)/manifest.json")
 SPARK_DIR ?= $(ROOT_DIR)/spark
 $(SPARK_DIR):
 	git clone $(SPARK_REPO_URL) $(SPARK_DIR)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ prod-dist: $(SPARK_DIR)
 	pushd $(SPARK_DIR)
 	rm -rf spark-*.tgz
 	./dev/change-scala-version.sh $(SCALA_VERSION)
-	./dev/make-distribution.sh --tgz -Pmesos "-Pscala-$(SCALA_VERSION)" "-Phadoop-$(HADOOP_VERSION)" -Pnetlib-lgpl -Psparkr -Phive -Phive-thriftserver -DskipTests
+	./dev/make-distribution.sh --tgz -Pmesos "-Pscala-$(SCALA_VERSION)" "-Phadoop-$(HADOOP_VERSION)" -Pnetlib-lgpl -Psparkr -Phive -Phive-thriftserver -DskipTests -Dmaven.test.skip=true -Dmaven.source.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true
 	filename=`ls spark-*.tgz`
 	rm -rf $(DIST_DIR)
 	mkdir -p $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ $(SPARK_DIR):
 prod-dist: $(SPARK_DIR)
 	pushd $(SPARK_DIR)
 	rm -rf spark-*.tgz
-	./dev/make-distribution.sh --tgz -Pmesos "-Phadoop-$(HADOOP_VERSION)" -Pnetlib-lgpl -Psparkr -Phive -Phive-thriftserver -DskipTests
+	./dev/change-scala-version.sh $(SCALA_VERSION)
+	./dev/make-distribution.sh --tgz -Pmesos "-Pscala-$(SCALA_VERSION)" "-Phadoop-$(HADOOP_VERSION)" -Pnetlib-lgpl -Psparkr -Phive -Phive-thriftserver -DskipTests
 	filename=`ls spark-*.tgz`
 	rm -rf $(DIST_DIR)
 	mkdir -p $(DIST_DIR)

--- a/bin/jenkins-package-publish.sh
+++ b/bin/jenkins-package-publish.sh
@@ -2,13 +2,18 @@
 
 set -e -x -o pipefail
 
-# $1: hadoop version (e.g. "2.6")
+# $1: scala version  (e.g. "2.11")
+# $2: hadoop version (e.g. "2.6")
 function docker_version() {
-    echo "${SPARK_BUILD_VERSION}-hadoop-$1"
+    echo "${SPARK_BUILD_VERSION}-scala-$1-hadoop-$2"
 }
 
 function default_hadoop_version {
     jq -r ".default_spark_dist.hadoop_version" "${SPARK_BUILD_DIR}/manifest.json"
+}
+
+function default_scala_version {
+    jq -r ".default_spark_dist.scala_version" "${SPARK_BUILD_DIR}/manifest.json"
 }
 
 function publish_docker_images() {
@@ -16,10 +21,11 @@ function publish_docker_images() {
     local NUM_SPARK_DIST=$(expr ${NUM_SPARK_DIST} - 1)
     for i in $(seq 0 ${NUM_SPARK_DIST});
     do
+        local SCALA_VERSION=$(jq -r ".spark_dist[${i}].scala_version" manifest.json)
         local HADOOP_VERSION=$(jq -r ".spark_dist[${i}].hadoop_version" manifest.json)
         make docker-dist \
             -e SPARK_DIST_URI=$(jq -r ".spark_dist[${i}].uri" manifest.json) \
-            -e DOCKER_DIST_IMAGE="${DOCKER_DIST_IMAGE}:$(docker_version ${HADOOP_VERSION})"
+            -e DOCKER_DIST_IMAGE="${DOCKER_DIST_IMAGE}:$(docker_version ${SCALA_VERSION} ${HADOOP_VERSION})"
         rm docker-dist # delete the docker-dist make target to clean
         make clean-dist
     done
@@ -27,7 +33,7 @@ function publish_docker_images() {
 
 
 function make_universe() {
-    DOCKER_VERSION=$(docker_version $(default_hadoop_version))
+    DOCKER_VERSION=$(docker_version $(default_scala_version) $(default_hadoop_version))
 
     make manifest-dist # use default manifest spark
     make stub-universe-url -e DOCKER_DIST_IMAGE=${DOCKER_DIST_IMAGE}:${DOCKER_VERSION}

--- a/bin/jenkins-package-publish.sh
+++ b/bin/jenkins-package-publish.sh
@@ -46,7 +46,7 @@ function write_properties() {
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SPARK_BUILD_DIR=${DIR}/..
-SPARK_BUILD_VERSION=${GIT_BRANCH#origin/tags/}
+SPARK_BUILD_VERSION=${SPARK_BUILD_VERSION:-${GIT_BRANCH#origin/tags/}}
 
 pushd "${SPARK_BUILD_DIR}"
 make docker-login

--- a/manifest.json
+++ b/manifest.json
@@ -3,28 +3,28 @@
     "default_spark_dist": {
         "scala_version": "2.12",
         "hadoop_version": "2.9",
-        "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.9.tgz"
+        "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.9.tgz"
     },
     "spark_dist": [
         {
             "scala_version": "2.12",
             "hadoop_version": "2.9",
-            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.9.tgz"
+            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.9.tgz"
         },
         {
             "scala_version": "2.12",
             "hadoop_version": "2.7",
-            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.7.tgz"
+            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.7.tgz"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.9",
-            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.11-hadoop-2.9.tgz"
+            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.9.tgz"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.7",
-            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.11-hadoop-2.7.tgz"
+            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.7.tgz"
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,30 +1,30 @@
 {
-    "spark_version": "2.4.0",
+    "spark_version": "2.4.3",
     "default_spark_dist": {
         "scala_version": "2.11",
         "hadoop_version": "2.9",
-        "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.9.tgz"
+        "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz"
     },
     "spark_dist": [
         {
             "scala_version": "2.12",
             "hadoop_version": "2.9",
-            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.9.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.9-SNAPSHOT-20190821.tgz"
         },
         {
             "scala_version": "2.12",
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.7.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.7-SNAPSHOT-20190821.tgz"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.9",
-            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.9.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.7.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.7-SNAPSHOT-20190821.tgz"
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,30 @@
 {
     "spark_version": "2.4.0",
     "default_spark_dist": {
+        "scala_version": "2.12",
         "hadoop_version": "2.9",
-        "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.9.2-openjdk8-SNAPSHOT-20190530.tgz"
+        "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.9.tgz"
     },
     "spark_dist": [
         {
+            "scala_version": "2.12",
             "hadoop_version": "2.9",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.9.2-openjdk8-SNAPSHOT-20190530.tgz"
+            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.9.tgz"
         },
         {
+            "scala_version": "2.12",
             "hadoop_version": "2.7",
-            "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.4.0-bin-hadoop2.7.7-openjdk8-SNAPSHOT-20190530.tgz"
+            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.12-hadoop-2.7.tgz"
+        },
+        {
+            "scala_version": "2.11",
+            "hadoop_version": "2.9",
+            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.11-hadoop-2.9.tgz"
+        },
+        {
+            "scala_version": "2.11",
+            "hadoop_version": "2.7",
+            "uri": "https://rpalaznik-dev.s3.amazonaws.com/dcos-54709/spark-2.4.0-bin-scala-2.11-hadoop-2.7.tgz"
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
     "spark_version": "2.4.0",
     "default_spark_dist": {
-        "scala_version": "2.12",
+        "scala_version": "2.11",
         "hadoop_version": "2.9",
-        "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.12-hadoop-2.9.tgz"
+        "uri": "https://downloads.mesosphere.io/spark/assets/spark-2.4.3-bin-scala-2.11-hadoop-2.9.tgz"
     },
     "spark_dist": [
         {

--- a/tests/jobs/python/shuffle_app.py
+++ b/tests/jobs/python/shuffle_app.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+import sys
+from random import getrandbits
+from time import sleep
+
+from pyspark.sql import SparkSession
+
+# ShuffleApp test job ported from Scala to Python
+
+if __name__ == "__main__":
+    spark = SparkSession \
+        .builder \
+        .appName("Shuffle Test") \
+        .getOrCreate()
+
+    num_mappers = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+    num_keys = int(sys.argv[2]) if len(sys.argv) > 2 else 1000
+    val_size = int(sys.argv[3]) if len(sys.argv) > 3 else 1000
+    num_reducers = int(sys.argv[4]) if len(sys.argv) > 4 else num_mappers
+    sleep_before_shutdown_millis = int(sys.argv[5]) if len(sys.argv) > 5 else 0
+
+    def f(_):
+        result = []
+        for i in range(num_keys):
+            arr = bytearray(getrandbits(8) for j in range(val_size))
+            result.append((i, arr))
+        return result
+
+    key_pairs = spark.sparkContext.parallelize(range(0, num_mappers), num_mappers).flatMap(f).cache()
+    key_pairs.count()
+
+    print("RDD content sample: {}".format(key_pairs.take(10)))
+
+    groups_count = key_pairs.groupByKey(num_reducers).count()
+    print("Groups count: {}".format(groups_count))
+
+    if sleep_before_shutdown_millis > 0:
+        sleep(sleep_before_shutdown_millis / 1000)
+
+    spark.stop()

--- a/tests/test_spark_distributions.py
+++ b/tests/test_spark_distributions.py
@@ -1,0 +1,49 @@
+import logging
+import os
+import pytest
+import spark_utils as utils
+
+
+log = logging.getLogger(__name__)
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+SMOKE_TEST_SPARK_DOCKER_IMAGES = os.getenv('SMOKE_TEST_SPARK_DOCKER_IMAGES', '')
+
+
+@pytest.mark.sanity
+@pytest.mark.smoke
+def test_spark_docker_images():
+    if not SMOKE_TEST_SPARK_DOCKER_IMAGES:
+        pytest.skip("A list of spark distribution images are required for this test")
+
+    docker_images = SMOKE_TEST_SPARK_DOCKER_IMAGES.split(',')
+
+    log.info("Testing the following docker images: ")
+    for image in docker_images:
+        log.info(" - " + image)
+
+    for image in docker_images:
+        log.info("Running a smoke test with " + image)
+        _test_spark_docker_image(image)
+
+
+def _test_spark_docker_image(docker_image):
+    utils.upload_dcos_test_jar()
+    utils.require_spark(additional_options={'service': {'docker-image': docker_image}})
+
+    expected_groups_count = 12000
+    num_mappers = 4
+    value_size_bytes = 100
+    num_reducers = 4
+    sleep = 500
+
+    python_script_path = os.path.join(THIS_DIR, 'jobs', 'python', 'shuffle_app.py')
+    python_script_url = utils.upload_file(python_script_path)
+    utils.run_tests(app_url=python_script_url,
+                    app_args="{} {} {} {} {}".format(num_mappers, expected_groups_count, value_size_bytes, num_reducers, sleep),
+                    expected_output="Groups count: {}".format(expected_groups_count),
+                    args=["--conf spark.executor.cores=1",
+                          "--conf spark.cores.max=4",
+                          "--conf spark.scheduler.minRegisteredResourcesRatio=1",
+                          "--conf spark.scheduler.maxRegisteredResourcesWaitingTime=3m"])
+
+    utils.teardown_spark()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-54709](https://jira.mesosphere.com/browse/DCOS-54709) - Add Scala 2.12 support for Spark

- Updated Makefile, and bin/jenkins-*.sh scripts to support multiple scala versions
- Updated manifest.json with new spark distributions with scala 2.12
- Default spark variant set to use hadoop-2.9 and scala 2.12
- Added a smoke test for custom spark docker images

## How were these changes tested?
I wanted to avoid creating test tags in git, so I tested the changes manually without using any production credentials, except uploading new spark distributions to downloads.mesosphere.io domain.

1)  Run the following script to build spark distribution archives:
```
SPARK_VERSION=2.4.3 \
DIST_DESTINATION_DIR=/tmp \
bin/jenkins-dist-publish.sh
```
Executed in `spark-tools` container, as described in the wiki. I had `mesosphere/spark` and `mesosphere/spark-build` repositories checked out and mounted next to each other. I've added DIST_DESTINATION_DIR variable to skip upload to S3 and save the archives locally.

2) Uploaded the spark distributions to downloads.mesosphere.io and updated manifest.json

3) Run the following script to build and push docker images to my personal docker hub account
```
DOCKER_USERNAME=rpalaznik \
DOCKER_PASSWORD=[redacted :)] \
SPARK_BUILD_VERSION=2.4.3 \
DOCKER_DIST_IMAGE=rpalaznik/spark \
GITHUB_DISABLE=true \
bin/jenkins-package-publish.sh
```

As I mentioned, this is just to test that the script is working. When making an actual release, you should simply create a release tag and run the jenkins job as described in the wiki.

4) Run the smoke test for custom docker images using the instructions from the wiki on how to run integration tests and by passing these variables
- `TEST_SH_SMOKE_TEST_SPARK_DOCKER_IMAGES='rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.7,rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.9,rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.7,rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.9'`
- `PYTEST_ARGS='-k test_spark_docker_images'`

If `TEST_SH_SMOKE_TEST_SPARK_DOCKER_IMAGES` is not set, e.g. during a CI integration test run, the smoke test will be skipped.

## Release Notes

- Added support for Spark distributions built with Scala 2.12
- Default spark distribution is built with Scala 2.12 and Hadoop 2.9 profiles
