### PR TITLE
[DCOS-58262] - Docker images in the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,28 +3,33 @@
     "default_spark_dist": {
         "scala_version": "2.11",
         "hadoop_version": "2.9",
-        "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz"
+        "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz",
+        "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.9"
     },
     "spark_dist": [
         {
             "scala_version": "2.12",
             "hadoop_version": "2.9",
-            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.9-SNAPSHOT-20190821.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.9-SNAPSHOT-20190821.tgz",
+            "image": "rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.9"
         },
         {
             "scala_version": "2.12",
             "hadoop_version": "2.7",
-            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.7-SNAPSHOT-20190821.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.7-SNAPSHOT-20190821.tgz",
+            "image": "rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.7"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.9",
-            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz",
+            "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.9"
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.7",
-            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.7-SNAPSHOT-20190821.tgz"
+            "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.7-SNAPSHOT-20190821.tgz",
+            "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.7"
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,32 +4,32 @@
         "scala_version": "2.11",
         "hadoop_version": "2.9",
         "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz",
-        "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.9"
+        "image": ""
     },
     "spark_dist": [
         {
             "scala_version": "2.12",
             "hadoop_version": "2.9",
             "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.9-SNAPSHOT-20190821.tgz",
-            "image": "rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.9"
+            "image": ""
         },
         {
             "scala_version": "2.12",
             "hadoop_version": "2.7",
             "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.12-hadoop-2.7-SNAPSHOT-20190821.tgz",
-            "image": "rpalaznik/spark:2.4.3-scala-2.12-hadoop-2.7"
+            "image": ""
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.9",
             "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.9-SNAPSHOT-20190821.tgz",
-            "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.9"
+            "image": ""
         },
         {
             "scala_version": "2.11",
             "hadoop_version": "2.7",
             "uri": "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-2.4.3-bin-scala-2.11-hadoop-2.7-SNAPSHOT-20190821.tgz",
-            "image": "rpalaznik/spark:2.4.3-scala-2.11-hadoop-2.7"
+            "image": ""
         }
     ]
 }

--- a/tests/test_spark_distributions.py
+++ b/tests/test_spark_distributions.py
@@ -2,48 +2,60 @@ import logging
 import os
 import pytest
 import spark_utils as utils
+import json
+import subprocess
 
 
 log = logging.getLogger(__name__)
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-SMOKE_TEST_SPARK_DOCKER_IMAGES = os.getenv('SMOKE_TEST_SPARK_DOCKER_IMAGES', '')
+EXAMPLES_JAR_PATH_TEMPLATE = "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/spark-examples_{}-2.4.3.jar"
 
 
 @pytest.mark.sanity
 @pytest.mark.smoke
 def test_spark_docker_images():
-    if not SMOKE_TEST_SPARK_DOCKER_IMAGES:
-        pytest.skip("A list of spark distribution images are required for this test")
 
-    docker_images = SMOKE_TEST_SPARK_DOCKER_IMAGES.split(',')
+    spark_dists = _read_dists_from_manifest()
 
-    log.info("Testing the following docker images: ")
-    for image in docker_images:
-        log.info(" - " + image)
+    log.info("Testing the following docker distributions: ")
+    for dist in spark_dists:
+        if not _docker_image_exists(dist['image']):
+            pytest.skip("Can't found one of docker images listed in manifest.json in the registry")
 
-    for image in docker_images:
-        log.info("Running a smoke test with " + image)
-        _test_spark_docker_image(image)
+    for dist in spark_dists:
+        log.info(f"Running a smoke test with {dist['image']}")
+        _test_spark_docker_image(dist)
 
 
-def _test_spark_docker_image(docker_image):
-    utils.upload_dcos_test_jar()
-    utils.require_spark(additional_options={'service': {'docker-image': docker_image}})
+def _read_dists_from_manifest():
+    with open(os.path.join(THIS_DIR, '..', 'manifest.json'), 'r') as file:
+        manifest = json.load(file)
+    return manifest['spark_dist']
+
+
+def _docker_image_exists(image):
+    log.info(f'Checking if image {image} exists in the registry')
+    completed = subprocess.run(f"DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect {image}")
+    return completed.returncode == 0
+
+
+def _test_spark_docker_image(dist):
+    utils.require_spark(additional_options={'service': {'docker-image': dist['image']}})
+    example_jar_url = EXAMPLES_JAR_PATH_TEMPLATE.format(dist['scala_version'])
 
     expected_groups_count = 12000
     num_mappers = 4
     value_size_bytes = 100
     num_reducers = 4
-    sleep = 500
 
-    python_script_path = os.path.join(THIS_DIR, 'jobs', 'python', 'shuffle_app.py')
-    python_script_url = utils.upload_file(python_script_path)
-    utils.run_tests(app_url=python_script_url,
-                    app_args="{} {} {} {} {}".format(num_mappers, expected_groups_count, value_size_bytes, num_reducers, sleep),
-                    expected_output="Groups count: {}".format(expected_groups_count),
-                    args=["--conf spark.executor.cores=1",
+    utils.run_tests(app_url=example_jar_url,
+                    app_args=f"{num_mappers} {expected_groups_count} {value_size_bytes} {num_reducers}",
+                    expected_output=str(expected_groups_count),
+                    args=["--class org.apache.spark.examples.GroupByTest",
+                          "--conf spark.executor.cores=1",
                           "--conf spark.cores.max=4",
                           "--conf spark.scheduler.minRegisteredResourcesRatio=1",
                           "--conf spark.scheduler.maxRegisteredResourcesWaitingTime=3m"])
 
     utils.teardown_spark()
+

--- a/tests/test_spark_distributions.py
+++ b/tests/test_spark_distributions.py
@@ -17,10 +17,10 @@ def test_spark_docker_images():
 
     spark_dists = _read_dists_from_manifest()
 
-    log.info("Testing the following docker distributions: ")
+    log.info("Testing docker distributions listed in manifest.json")
     for dist in spark_dists:
         if not _docker_image_exists(dist['image']):
-            pytest.skip("Can't found one of docker images listed in manifest.json in the registry")
+            pytest.skip(f"Can't found image {dist['image']} listed in manifest.json in the registry")
 
     for dist in spark_dists:
         log.info(f"Running a smoke test with {dist['image']}")

--- a/tests/test_spark_distributions.py
+++ b/tests/test_spark_distributions.py
@@ -18,13 +18,16 @@ def test_spark_docker_images():
     spark_dists = _read_dists_from_manifest()
 
     log.info("Testing docker distributions listed in manifest.json")
+
+    # Making sure all listed docker images exist before running any tests
     for dist in spark_dists:
-        if not _docker_image_exists(dist['image']):
+        if dist.get('image') and not _docker_image_exists(dist['image']):
             pytest.skip(f"Can't found image {dist['image']} listed in manifest.json in the registry")
 
     for dist in spark_dists:
-        log.info(f"Running a smoke test with {dist['image']}")
-        _test_spark_docker_image(dist)
+        if dist.get('image'):
+            log.info(f"Running a smoke test with {dist['image']}")
+            _test_spark_docker_image(dist)
 
 
 def _read_dists_from_manifest():

--- a/tests/test_spark_distributions.py
+++ b/tests/test_spark_distributions.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import spark_utils as utils
 import json
-import subprocess
+import requests
 
 
 log = logging.getLogger(__name__)
@@ -35,8 +35,9 @@ def _read_dists_from_manifest():
 
 def _docker_image_exists(image):
     log.info(f'Checking if image {image} exists in the registry')
-    completed = subprocess.run(f"DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect {image}")
-    return completed.returncode == 0
+    name, tag = image.split(':')
+    r = requests.get(f"https://hub.docker.com/v2/repositories/{name}/tags/{tag}")
+    return r.status_code == 200
 
 
 def _test_spark_docker_image(dist):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-58262](https://jira.mesosphere.com/browse/DCOS-58262)

- List docker images for different spark distributions in manifest.json
- The smoke test for custom docker images will now run automatically and use the images from manifest.json. The property for docker image is optional, but if any of the listed images does not exist, the test will be skipped.
- The smoke test for custom docker images will use GroupBy example job instead of shuffle_app.py

## How were these changes tested?

The test run in a standalone cluster in AWS. 

Note: I listed docker images from my personal repository for now, to make CI build more meaningful. I'll remove them before merging.
