### PR TITLE
Stop agent's domain socket, which leads to systemd restarting the age…

### DIFF
--- a/spark-testing/spark_utils.py
+++ b/spark-testing/spark_utils.py
@@ -46,8 +46,8 @@ log = logging.getLogger(__name__)
 SPARK_PACKAGE_NAME = os.getenv("SPARK_PACKAGE_NAME", "spark")
 SPARK_EXAMPLES = "http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.4.0.jar"
 
-start_agent_cmd = "sudo systemctl start dcos-mesos-slave"
-stop_agent_cmd = "sudo systemctl stop dcos-mesos-slave"
+start_agent_cmd = "sudo systemctl start dcos-mesos-slave.service dcos-mesos-slave.socket"
+stop_agent_cmd = "sudo systemctl stop dcos-mesos-slave.service dcos-mesos-slave.socket"
 check_agent_cmd = "sudo systemctl is-active dcos-mesos-slave"
 
 

--- a/tests/test_mesos_checkpointing.py
+++ b/tests/test_mesos_checkpointing.py
@@ -47,10 +47,6 @@ def setup_spark(configure_security_spark, configure_universe):
 
 
 @pytest.mark.sanity
-@pytest.mark.skipif(
-    '2.1.0' == sdk_utils.dcos_version(),
-    reason="Since DC/OS 2.1.0 is unable to stop dcos-mesos-slave, refer this https://jira.d2iq.com/browse/D2IQ-69935"
-)
 def test_agent_restart_with_checkpointing_disabled():
     (driver_task_id, driver_task, executor_task) = _submit_job_and_get_tasks()
 
@@ -66,10 +62,6 @@ def test_agent_restart_with_checkpointing_disabled():
 
 
 @pytest.mark.sanity
-@pytest.mark.skipif(
-    '2.1.0' == sdk_utils.dcos_version(),
-    reason="Since DC/OS 2.1.0 is unable to stop dcos-mesos-slave, refer this https://jira.d2iq.com/browse/D2IQ-69935"
-)
 def test_agent_restart_with_checkpointing_enabled():
     (driver_task_id, driver_task, executor_task) = _submit_job_and_get_tasks(extra_args=["--conf spark.mesos.checkpoint=true"])
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
Fix for stopping Mesos agent in tests.

Once we take down the Mesos agent, if a task with an HTTP executor is running on the node, the executor will immediately attempt to connect to the agent's domain socket, which leads to systemd restarting the agent.

In order to prevent this, it looks like we now need to stop the Mesos agent using:
`sudo systemctl stop dcos-mesos-slave.service dcos-mesos-slave.socket`
Then, restarting the agent can be accomplished with:
`sudo systemctl start dcos-mesos-slave.service dcos-mesos-slave.socket`

Related ticket - [D2IQ-69935](https://jira.d2iq.com/browse/D2IQ-69935)